### PR TITLE
Add Albunyaan Tube design documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Albunyaan Tube Design Repository
+
+Welcome to the design workspace for Albunyaan Tube, an ad-free, admin-curated halal YouTube client. This repository captures all discovery outcomes, architectural decisions, experience specifications, and planning artifacts required before implementation. The materials are organized by discipline and phase to keep product, engineering, and design aligned.
+
+## How to Navigate
+- Start with [`docs/vision/vision.md`](docs/vision/vision.md) to understand goals, success metrics, and guardrails.
+- Review the phased delivery plan in [`docs/roadmap/roadmap.md`](docs/roadmap/roadmap.md) which maps required deliverables to milestones.
+- Experience specifications, including canonical layouts and design tokens, live in [`docs/ux/ui-spec.md`](docs/ux/ui-spec.md) and [`docs/ux/design-tokens.json`](docs/ux/design-tokens.json).
+- Solution architecture, C4 diagrams, and integration sequences are in [`docs/architecture`](docs/architecture).
+- API contracts are drafted in [`docs/api/openapi-draft.yaml`](docs/api/openapi-draft.yaml) with supporting JSON Schemas under [`docs/data/json-schemas`](docs/data/json-schemas).
+- Security, internationalization, testing, and acceptance criteria are documented in their respective folders.
+- Product backlog and risk register are maintained in [`docs/backlog/product-backlog.csv`](docs/backlog/product-backlog.csv) and [`docs/risk-register.md`](docs/risk-register.md).
+
+## Traceability
+Every document references related artifacts to ensure consistency:
+- Requirements → APIs → Acceptance criteria are linked through the traceability matrix in [`docs/acceptance/criteria.md`](docs/acceptance/criteria.md).
+- Security controls, data models, and internationalization strategies are cross-linked within architecture and API sections.
+
+## Change Workflow
+1. Update relevant design artifact(s).
+2. Ensure cross-references remain valid.
+3. Run documentation linters (TBD in future phases).
+4. Submit for stakeholder review per phase exit criteria.
+
+These documents will evolve through the pre-development phases until implementation is approved.

--- a/docs/acceptance/criteria.md
+++ b/docs/acceptance/criteria.md
@@ -1,0 +1,65 @@
+# Acceptance Criteria & Traceability Matrix
+
+This document enumerates verifiable acceptance criteria linked to requirements, APIs, and test coverage. Use the IDs when creating tickets in [`../backlog/product-backlog.csv`](../backlog/product-backlog.csv).
+
+## Legend
+- **REQ**: High-level requirement from vision.
+- **AC**: Acceptance criterion.
+- **API**: Endpoint reference (see [`../api/openapi-draft.yaml`](../api/openapi-draft.yaml)).
+- **TEST**: Pointer to test strategy section.
+
+## Traceability Matrix
+| REQ | Description | AC ID | Acceptance Criterion | API | TEST |
+| --- | --- | --- | --- | --- | --- |
+| R1 | Halal allow-listed catalog | AC-REG-001 | All Channels/Playlists/Videos require ≥1 category; attempts to save without fail validation. | `/channels`, `/playlists`, `/videos` | Backend Integration |
+| R1 |  | AC-REG-002 | Moderation approval logs decision with actor, timestamp. | `/moderation/proposals/{id}/approve` | Backend Integration + Audit tests |
+| R2 | Frictionless consumption | AC-AND-001 | Home feed renders sections (Channels/Playlists/Videos) each limited to 3 latest per source. | `/home` | Android Paging tests |
+| R2 |  | AC-AND-002 | Player disables autoplay on completion; shows replay button. | N/A (client logic) | Android Instrumentation |
+| R2 |  | AC-AND-003 | Audio-only toggle switches ExoPlayer to audio stream without restarting playback. | `/videos/{id}` | Player Reliability |
+| R3 | Operational governance | AC-ADM-001 | Admin user CRUD enforces RBAC (only ADMIN can create). | `/admin/users` | Backend Security tests |
+| R3 |  | AC-ADM-002 | Audit list paginates via cursor; next cursor null when end reached. | `/admin/audit` | Admin E2E |
+| R4 | Localization quality | AC-I18N-001 | API responses honor `Accept-Language` (ar, nl) with fallback to `en`. | all localized endpoints | Backend Integration |
+| R4 |  | AC-I18N-002 | Android UI mirrors layout in Arabic including bottom nav order. | N/A | Android Localization |
+| R5 | Downloads policy | AC-DL-001 | Playlist download button disabled when `downloadPolicy=DISABLED_BY_POLICY`. | `/playlists/{id}` | Android Instrumentation |
+| R5 |  | AC-DL-002 | Offline playback blocked until EULA accepted; acceptance recorded. | `/auth/login` (EULA flag) | Android Instrumentation + Backend |
+| R6 | Security | AC-SEC-001 | Access token expires 15m; refresh rotates and blacklists prior tokens. | `/auth/refresh` | Security Tests |
+| R6 |  | AC-SEC-002 | Rate limit exceeded returns 429 with localized error. | all endpoints | Performance/Security |
+| R7 | Performance | AC-PERF-001 | List payloads ≤80KB per page at limit=20. | `/videos`, `/channels`, `/playlists` | Performance Tests |
+| R7 |  | AC-PERF-002 | Android cold start <2.5s on mid-range device (Pixel 4a) measured via benchmark. | N/A | Android Performance |
+
+## Android Client Criteria
+- **AC-AND-004**: Splash screen visible ≥1.5s while data loads (See [`../ux/ui-spec.md`](../ux/ui-spec.md#splash)).
+- **AC-AND-005**: Onboarding supports en/ar/nl with help modal accessible (RTL mirrored).
+- **AC-AND-006**: Category filter persists across Home/Channels/Playlists/Videos tabs.
+- **AC-AND-007**: Background playback continues with notification + MediaSession actions (play/pause/skip). Failure triggers retry/backoff.
+
+## Admin Console Criteria
+- **AC-ADM-003**: Moderation queue supports status filter, default `PENDING` sorted oldest first.
+- **AC-ADM-004**: Category editor prevents deleting category assigned to content; suggests reassignment.
+- **AC-ADM-005**: Exclusions view shows parent + excluded entity with reason.
+
+## Backend Criteria
+- **AC-BE-001**: Cursor parameters validated; invalid cursor returns 400 with `error=CLIENT_ERROR`.
+- **AC-BE-002**: `/next-up` returns only allow-listed IDs not excluded by parent.
+- **AC-BE-003**: Redis cache invalidated within 5s after moderation approval.
+
+## Internationalization Criteria
+- **AC-I18N-003**: Numeric values use locale digits (Arabic Indic digits for `ar`).
+- **AC-I18N-004**: Dates formatted using Umm al-Qura calendar? (Decision: use Gregorian with localized month names, documented here.)
+
+## Accessibility Criteria
+- **AC-A11Y-001**: All interactive elements have TalkBack labels (Android) or `aria-label` (Admin).
+- **AC-A11Y-002**: Color contrast meets WCAG AA per design tokens.
+- **AC-A11Y-003**: Focus order follows visual hierarchy; tested on Android (TalkBack) and web (keyboard).
+
+## Downloads & Offline Criteria
+- **AC-DL-003**: Downloads limited to app-private storage; hitting quota prompts user with localized message referencing policy.
+- **AC-DL-004**: Playlist download surfaces aggregated progress with cancel/resume controls.
+
+## Observability Criteria
+- **AC-OBS-001**: Each API response includes `traceId` header.
+- **AC-OBS-002**: Metrics emitted for `moderation.pending.count` and `downloads.active.count`.
+
+## Change Management
+- All acceptance criteria must have corresponding test cases (see [`../testing/test-strategy.md`](../testing/test-strategy.md)).
+- During Phase reviews, update this document with status per AC.

--- a/docs/api/openapi-draft.yaml
+++ b/docs/api/openapi-draft.yaml
@@ -1,0 +1,492 @@
+openapi: 3.1.0
+info:
+  title: Albunyaan Tube API
+  version: 0.1.0
+  description: |
+    Draft REST contract for Albunyaan Tube backend. All list endpoints use cursor-based pagination with opaque cursors.
+    Localized fields respond to `Accept-Language` header with fallback to English.
+servers:
+  - url: https://api.albunyaan.tld/v1
+    description: Production
+  - url: https://staging-api.albunyaan.tld/v1
+    description: Staging
+security:
+  - bearerAuth: []
+paths:
+  /auth/login:
+    post:
+      summary: Authenticate admin or moderator
+      operationId: login
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/auth-login-request.json'
+      responses:
+        '200':
+          description: Tokens issued
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/auth-login-response.json'
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+  /auth/refresh:
+    post:
+      summary: Rotate refresh token
+      operationId: refreshToken
+      tags: [Auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/auth-refresh-request.json'
+      responses:
+        '200':
+          description: Tokens rotated
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/auth-login-response.json'
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+  /auth/logout:
+    post:
+      summary: Invalidate refresh token and blacklist access token
+      operationId: logout
+      tags: [Auth]
+      responses:
+        '204': { description: Logged out }
+        '401': { $ref: '#/components/responses/UnauthorizedError' }
+  /admin/users:
+    get:
+      summary: List users
+      operationId: listUsers
+      tags: [Users]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Users page
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/admin-users-page.json'
+    post:
+      summary: Create user
+      operationId: createUser
+      tags: [Users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/admin-user-create-request.json'
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/admin-user-response.json'
+  /admin/users/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      summary: Get user
+      operationId: getUser
+      tags: [Users]
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '../data/json-schemas/admin-user-response.json' } } } }
+    put:
+      summary: Update user
+      operationId: updateUser
+      tags: [Users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/admin-user-update-request.json'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/admin-user-response.json'
+    delete:
+      summary: Delete user
+      operationId: deleteUser
+      tags: [Users]
+      responses:
+        '204': { description: Deleted }
+  /categories:
+    get:
+      summary: List categories
+      operationId: listCategories
+      tags: [Categories]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Category page
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/category-page.json'
+    post:
+      summary: Create category
+      operationId: createCategory
+      tags: [Categories]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/category-create-request.json'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/category-response.json'
+  /categories/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      summary: Get category
+      operationId: getCategory
+      tags: [Categories]
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '../data/json-schemas/category-response.json' } } } }
+    put:
+      summary: Update category
+      operationId: updateCategory
+      tags: [Categories]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/category-update-request.json'
+      responses:
+        '200': { description: Updated, content: { application/json: { schema: { $ref: '../data/json-schemas/category-response.json' } } } }
+    delete:
+      summary: Archive category
+      operationId: deleteCategory
+      tags: [Categories]
+      responses:
+        '204': { description: Deleted }
+  /home:
+    get:
+      summary: Aggregated home feed
+      operationId: getHome
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CategoryIdQuery'
+      responses:
+        '200':
+          description: Home sections with 3-latest rule
+          content:
+            application/json:
+              schema:
+                $ref: '../data/json-schemas/home-response.json'
+  /channels:
+    get:
+      summary: List channels
+      operationId: listChannels
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CategoryIdQuery'
+      responses:
+        '200': { description: Channels page, content: { application/json: { schema: { $ref: '../data/json-schemas/channel-page.json' } } } }
+  /channels/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      summary: Channel detail
+      operationId: getChannel
+      tags: [Registry]
+      responses:
+        '200': { description: Channel detail, content: { application/json: { schema: { $ref: '../data/json-schemas/channel-detail.json' } } } }
+  /channels/{id}/videos:
+    get:
+      summary: Channel videos
+      operationId: getChannelVideos
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Video page, content: { application/json: { schema: { $ref: '../data/json-schemas/video-page.json' } } } }
+  /channels/{id}/live:
+    get:
+      summary: Channel live streams
+      operationId: getChannelLive
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Live page, content: { application/json: { schema: { $ref: '../data/json-schemas/live-page.json' } } } }
+  /channels/{id}/shorts:
+    get:
+      summary: Channel shorts
+      operationId: getChannelShorts
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Shorts page, content: { application/json: { schema: { $ref: '../data/json-schemas/video-page.json' } } } }
+  /channels/{id}/playlists:
+    get:
+      summary: Channel playlists
+      operationId: getChannelPlaylists
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Playlist page, content: { application/json: { schema: { $ref: '../data/json-schemas/playlist-page.json' } } } }
+  /channels/{id}/posts:
+    get:
+      summary: Channel posts (community)
+      operationId: getChannelPosts
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Posts page, content: { application/json: { schema: { $ref: '../data/json-schemas/post-page.json' } } } }
+  /playlists:
+    get:
+      summary: List playlists
+      operationId: listPlaylists
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/CategoryIdQuery'
+      responses:
+        '200': { description: Playlists page, content: { application/json: { schema: { $ref: '../data/json-schemas/playlist-page.json' } } } }
+  /playlists/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      summary: Playlist detail
+      operationId: getPlaylist
+      tags: [Registry]
+      responses:
+        '200': { description: Playlist detail, content: { application/json: { schema: { $ref: '../data/json-schemas/playlist-detail.json' } } } }
+  /playlists/{id}/videos:
+    get:
+      summary: Videos in playlist
+      operationId: getPlaylistVideos
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Video page, content: { application/json: { schema: { $ref: '../data/json-schemas/video-page.json' } } } }
+  /videos:
+    get:
+      summary: Search videos
+      operationId: listVideos
+      tags: [Registry]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - name: categoryId
+          in: query
+          schema: { type: string }
+        - name: q
+          in: query
+          schema: { type: string, maxLength: 120 }
+        - name: length
+          in: query
+          schema: { type: string, enum: [SHORT, MEDIUM, LONG] }
+        - name: date
+          in: query
+          schema: { type: string, enum: [LAST_24_HOURS, LAST_7_DAYS, LAST_30_DAYS, ANYTIME] }
+        - name: sort
+          in: query
+          schema: { type: string, enum: [RECENT, POPULAR] }
+      responses:
+        '200': { description: Video page, content: { application/json: { schema: { $ref: '../data/json-schemas/video-page.json' } } } }
+  /videos/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      summary: Video detail
+      operationId: getVideo
+      tags: [Registry]
+      responses:
+        '200': { description: Video detail, content: { application/json: { schema: { $ref: '../data/json-schemas/video-detail.json' } } } }
+  /next-up:
+    get:
+      summary: Up-next recommendations
+      operationId: getNextUp
+      tags: [Registry]
+      parameters:
+        - name: videoId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Next up list, content: { application/json: { schema: { $ref: '../data/json-schemas/video-page.json' } } } }
+  /moderation/proposals:
+    post:
+      summary: Submit moderation proposal
+      operationId: createProposal
+      tags: [Moderation]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/moderation-proposal-create-request.json'
+      responses:
+        '201': { description: Created, content: { application/json: { schema: { $ref: '../data/json-schemas/moderation-proposal-response.json' } } } }
+    get:
+      summary: List moderation proposals
+      operationId: listProposals
+      tags: [Moderation]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - name: status
+          in: query
+          schema: { type: string, enum: [PENDING, APPROVED, REJECTED] }
+      responses:
+        '200': { description: Proposal page, content: { application/json: { schema: { $ref: '../data/json-schemas/moderation-proposal-page.json' } } } }
+  /moderation/proposals/{id}/approve:
+    post:
+      summary: Approve proposal
+      operationId: approveProposal
+      tags: [Moderation]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+      responses:
+        '200': { description: Approved, content: { application/json: { schema: { $ref: '../data/json-schemas/moderation-proposal-response.json' } } } }
+  /moderation/proposals/{id}/reject:
+    post:
+      summary: Reject proposal
+      operationId: rejectProposal
+      tags: [Moderation]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/moderation-proposal-reject-request.json'
+      responses:
+        '200': { description: Rejected, content: { application/json: { schema: { $ref: '../data/json-schemas/moderation-proposal-response.json' } } } }
+  /exclusions:
+    post:
+      summary: Create exclusion
+      operationId: createExclusion
+      tags: [Moderation]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../data/json-schemas/exclusion-create-request.json'
+      responses:
+        '201': { description: Created, content: { application/json: { schema: { $ref: '../data/json-schemas/exclusion-response.json' } } } }
+  /exclusions/{id}:
+    delete:
+      summary: Delete exclusion
+      operationId: deleteExclusion
+      tags: [Moderation]
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+      responses:
+        '204': { description: Deleted }
+  /admin/search:
+    get:
+      summary: Search YouTube via server-side API
+      operationId: adminSearch
+      tags: [Admin]
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema: { type: string, maxLength: 120 }
+        - name: type
+          in: query
+          required: true
+          schema: { type: string, enum: [CHANNEL, PLAYLIST, VIDEO] }
+      responses:
+        '200': { description: Search results, content: { application/json: { schema: { $ref: '../data/json-schemas/admin-search-response.json' } } } }
+  /admin/audit:
+    get:
+      summary: List audit logs
+      operationId: listAudit
+      tags: [Admin]
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200': { description: Audit page, content: { application/json: { schema: { $ref: '../data/json-schemas/audit-page.json' } } } }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    CursorParam:
+      name: cursor
+      in: query
+      required: false
+      description: Opaque base64 cursor provided in previous response.
+      schema:
+        type: string
+        maxLength: 512
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    IdPathParam:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    CategoryIdQuery:
+      name: categoryId
+      in: query
+      required: false
+      schema:
+        type: string
+  responses:
+    UnauthorizedError:
+      description: Authentication failed
+      content:
+        application/json:
+          schema:
+            $ref: '../data/json-schemas/error-response.json'

--- a/docs/architecture/diagrams/backend-components.md
+++ b/docs/architecture/diagrams/backend-components.md
@@ -1,0 +1,34 @@
+# C4 Level 3 — Backend Component Diagram
+
+```mermaid
+C4Component
+    title Backend Components
+    Container_Boundary(backend, "Albunyaan Tube Backend") {
+        Component(api, "REST Controllers", "Spring MVC", "Expose endpoints defined in OpenAPI")
+        Component(security, "Security Layer", "Spring Security", "JWT validation, RBAC, rate limits")
+        Component(service, "Domain Services", "Java", "Business rules: curation, pagination, downloads")
+        Component(moderation, "Moderation Service", "Java", "Proposal workflow, approvals, audit trail")
+        Component(registry, "Registry Service", "Java", "Channel/Playlist/Video management")
+        Component(repo, "Repositories", "Spring Data JPA", "Persistence for core entities")
+        Component(cache, "Cache Gateway", "Java", "Redis abstraction, TTL policies")
+        Component(integration, "NewPipe Integration", "Java", "Calls NewPipeExtractor")
+        Component(audit, "Audit Logger", "Java", "Writes immutable audit events")
+    }
+
+    ContainerDb(postgres, "PostgreSQL", "RDBMS")
+    ContainerDb(redis, "Redis", "Cache")
+    Container(adminSpa, "Admin SPA", "Vue 3")
+    Container(android, "Android App", "Android")
+
+    Rel(adminSpa, api, "HTTPS JSON")
+    Rel(android, api, "HTTPS JSON")
+    Rel(api, security, "Delegates auth")
+    Rel(api, service, "Invokes use cases")
+    Rel(service, repo, "CRUD operations")
+    Rel(service, cache, "Read/Write cached responses")
+    Rel(cache, redis, "Serialize")
+    Rel(repo, postgres, "JPA")
+    Rel(service, integration, "Enrich metadata")
+    Rel(moderation, audit, "Write approvals/rejections")
+    Rel(audit, postgres, "Append-only table")
+```

--- a/docs/architecture/diagrams/channel-tabs-sequence.md
+++ b/docs/architecture/diagrams/channel-tabs-sequence.md
@@ -1,0 +1,27 @@
+# Channel Tabs Data Fetch Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Android App
+    participant Repo as ChannelRepository
+    participant API as Backend API
+    participant Cache as Redis
+    participant DB as PostgreSQL
+
+    App->>Repo: loadChannelTabs(channelId, locale)
+    Repo->>API: GET /channels/{id}?locale
+    API->>Cache: fetch channel detail cache key
+    Cache-->>API: miss
+    API->>DB: SELECT channel + i18n fields
+    API->>Cache: store channel detail (TTL 10m)
+    API-->>Repo: 200 OK ChannelDetail
+
+    App->>Repo: loadVideosTab(cursor=null)
+    Repo->>API: GET /channels/{id}/videos?cursor=
+    API->>Cache: fetch list cache key (channelId, locale, cursor)
+    Cache-->>API: hit/miss (if miss, fallback to DB query)
+    API->>DB: SELECT latest videos ORDER BY publishedAt DESC LIMIT pageSize (if miss)
+    API->>Cache: store page (TTL 5m)
+    API-->>Repo: 200 OK CursorPage
+    Repo-->>App: Render list with Paging 3; handles cursor for next page
+```

--- a/docs/architecture/diagrams/container.md
+++ b/docs/architecture/diagrams/container.md
@@ -1,0 +1,33 @@
+# C4 Level 2 — Container Diagram
+
+```mermaid
+C4Container
+    title Albunyaan Tube Container Diagram
+    Person(muslimUser, "Android User")
+    Person(adminUser, "Admin/Moderator")
+
+    Container_Boundary(atube, "Albunyaan Tube Platform") {
+        Container(androidApp, "Android App", "Android, Java", "UI, playback, downloads, offline cache")
+        Container(adminSpa, "Admin SPA", "Vue 3, TypeScript", "Registry management UI")
+        Container(backend, "Backend API", "Spring Boot", "REST APIs, business logic")
+        ContainerDb(postgres, "PostgreSQL", "RDS", "Persistent storage for catalog")
+        ContainerDb(redis, "Redis", "Managed Cache", "Caching, rate limit, JWT blacklist")
+        Container(scheduler, "Worker / Scheduler", "Spring Boot", "Metadata refresh via NewPipeExtractor")
+    }
+
+    Container_Ext(newPipe, "NewPipeExtractor", "Java library", "YouTube metadata extraction")
+    Container_Ext(youtubeCdn, "YouTube CDN", "HTTPS", "Video/audio delivery")
+    Container_Ext(fcm, "FCM", "Google Cloud", "Notifications")
+
+    Rel(muslimUser, androidApp, "Uses")
+    Rel(adminUser, adminSpa, "Manages content")
+    Rel(adminSpa, backend, "REST/JSON", "HTTPS + JWT + CSRF")
+    Rel(androidApp, backend, "REST/JSON", "HTTPS + JWT")
+    Rel(backend, postgres, "JDBC", "TLS")
+    Rel(backend, redis, "Lettuce", "TLS")
+    Rel(scheduler, newPipe, "Metadata fetch")
+    Rel(backend, newPipe, "Ad-hoc fetch")
+    Rel(backend, youtubeCdn, "Generate stream URLs")
+    Rel(androidApp, youtubeCdn, "Stream playback")
+    Rel(backend, fcm, "Send notifications")
+```

--- a/docs/architecture/diagrams/context.md
+++ b/docs/architecture/diagrams/context.md
@@ -1,0 +1,26 @@
+# C4 Level 1 — System Context
+
+```mermaid
+C4Context
+    title Albunyaan Tube Context Diagram
+    Person(muslimUser, "Android User", "Consumes halal video content")
+    Person(adminUser, "Admin/Moderator", "Curates and moderates catalog")
+
+    System_Boundary(atube, "Albunyaan Tube Platform") {
+        System(backend, "Albunyaan Tube Backend", "Spring Boot service providing REST APIs")
+        System(adminUi, "Admin Web Console", "Vue 3 SPA for registry management")
+        System(androidApp, "Android Client", "Native Android app with ExoPlayer")
+    }
+
+    System_Ext(newPipe, "NewPipeExtractor", "Fetches stream metadata from YouTube")
+    System_Ext(youtube, "YouTube CDN", "Delivers video/audio streams")
+    System_Ext(push, "Firebase Cloud Messaging", "Delivers notifications")
+
+    Rel(muslimUser, androidApp, "Uses", "HTTPS")
+    Rel(adminUser, adminUi, "Manages content", "HTTPS + JWT")
+    Rel(androidApp, backend, "Calls API", "REST/JSON")
+    Rel(adminUi, backend, "Calls API", "REST/JSON + CSRF")
+    Rel(backend, newPipe, "Retrieves metadata", "Library call")
+    Rel(backend, youtube, "Provides signed stream URLs", "HTTPS")
+    Rel(backend, push, "Sends download notifications", "HTTPS")
+```

--- a/docs/architecture/diagrams/moderation-sequence.md
+++ b/docs/architecture/diagrams/moderation-sequence.md
@@ -1,0 +1,26 @@
+# Moderation Proposal Sequence
+
+```mermaid
+sequenceDiagram
+    participant Admin as Admin UI
+    participant API as Backend API
+    participant ModSvc as Moderation Service
+    participant Audit as Audit Logger
+    participant DB as PostgreSQL
+
+    Admin->>API: POST /moderation/proposals (ytId, kind, categories)
+    API->>ModSvc: validate + create proposal
+    ModSvc->>DB: INSERT ModerationItem (status=PENDING)
+    ModSvc->>Audit: record "proposal_created"
+    Audit->>DB: INSERT AuditLog
+    API-->>Admin: 201 Created + proposalId
+
+    Admin->>API: POST /moderation/proposals/{id}/approve
+    API->>ModSvc: authorize (role=ADMIN|MODERATOR)
+    ModSvc->>DB: UPDATE ModerationItem (status=APPROVED, decidedBy, decidedAt)
+    ModSvc->>DB: UPSERT registry entity (Channel/Playlist/Video)
+    ModSvc->>Audit: record "proposal_approved"
+    Audit->>DB: INSERT AuditLog
+    ModSvc->>Redis: invalidate caches for category filters
+    API-->>Admin: 200 OK
+```

--- a/docs/architecture/solution-architecture.md
+++ b/docs/architecture/solution-architecture.md
@@ -1,0 +1,62 @@
+# Solution Architecture Overview
+
+This document summarizes the end-to-end architecture for Albunyaan Tube. Detailed diagrams reside in [`docs/architecture/diagrams`](diagrams). API contracts are defined in [`../api/openapi-draft.yaml`](../api/openapi-draft.yaml). Security considerations are elaborated in [`../security/threat-model.md`](../security/threat-model.md).
+
+## C4 Summary
+- **Context**: See [`diagrams/context.md`](diagrams/context.md) for relationships among actors (Android client, Admin UI, Spring Boot backend, PostgreSQL, Redis, external NewPipeExtractor and YouTube).
+- **Container**: [`diagrams/container.md`](diagrams/container.md) describes deployment units (Android app, Admin SPA, Backend service, Databases, CDN).
+- **Component**: [`diagrams/backend-components.md`](diagrams/backend-components.md) details backend layers (API, Service, Repository, Integration).
+- **Sequence**: Interaction flows for moderation approvals in [`diagrams/moderation-sequence.md`](diagrams/moderation-sequence.md) and channel tab retrieval in [`diagrams/channel-tabs-sequence.md`](diagrams/channel-tabs-sequence.md).
+
+## Backend Architecture
+- **Language/Framework**: Java 17, Spring Boot 3 with Web, Security, Validation, Data JPA modules.
+- **Persistence**: PostgreSQL 15 (primary data store) managed via Flyway migrations; Redis for caching, rate limiting, JWT blacklist.
+- **Integration**: NewPipeExtractor library used via dedicated integration component to fetch metadata and stream URLs for allow-listed IDs.
+- **API Style**: REST with JSON; localized responses based on `Accept-Language` with fallback to English.
+- **Caching Strategy**: Redis caches popular list queries keyed by locale + category + cursor. Time-to-live 5 minutes with cache stampede protection (locking). Downloadable assets served via signed URLs; consider CDN for thumbnails.
+- **Security Architecture**: JWT-based auth with rotation and blacklist (see [`../security/threat-model.md`](../security/threat-model.md#controls)). RBAC roles ADMIN and MODERATOR enforced through Spring Security method-level annotations. Rate limiting via Redis sliding window.
+- **Observability**: Structured logging (JSON), distributed tracing with OpenTelemetry, metrics exported to Prometheus. Error taxonomy defined in [`../testing/test-strategy.md`](../testing/test-strategy.md#error-taxonomy).
+
+## Domain Model
+Entities defined in [`../data/json-schemas`](../data/json-schemas):
+- User, Role (RBAC)
+- Category (i18n map, slug)
+- Channel, Playlist, Video (each referencing categories and i18n fields)
+- ModerationItem, Exclusion, AuditLog
+These schemas inform JPA entities and API payloads.
+
+## Android Architecture
+- **Layers**: Presentation (Jetpack ViewModel), Domain (use cases), Data (Repository → Retrofit/OkHttp for backend, Room for offline downloads metadata).
+- **Navigation**: Single-activity pattern with Navigation Component; bottom nav (Home, Channels, Playlists, Videos). Onboarding flow controlled via DataStore preference.
+- **Playback Engine**: ExoPlayer integrated with MediaSession + Notification for background playback. Audio-only toggle selects audio stream variant from backend-provided manifest. PiP supported via Android 12 APIs. See Phase 8 plan in [`../testing/test-strategy.md`](../testing/test-strategy.md#player-reliability).
+- **Downloads**: Foreground service with WorkManager orchestrating downloads; store files in app-private storage with quotas (see [`../security/threat-model.md`](../security/threat-model.md#policy-controls)).
+- **Localization**: Locale switcher per [`../i18n/strategy.md`](../i18n/strategy.md#android-implementation); full RTL mirroring.
+
+## Admin Frontend Architecture
+- Vue 3 + Vite + TypeScript, Pinia for state management, Vue Router for routing, vue-i18n for localization.
+- Modules: Auth shell, Registry management, Moderation queue, Users, Audit logs.
+- API client generated from OpenAPI via `openapi-typescript`. State stores align with pagination contract (cursor-based).
+- Security: JWT stored in HTTP-only cookies; CSRF tokens for state-changing operations.
+
+## Data Flow
+1. Admin allow-lists content by storing Channel/Playlist/Video entries with categories.
+2. Backend sync job (WorkManager or scheduled) enriches metadata via NewPipeExtractor when new IDs added.
+3. Android client requests lists with cursor pagination; backend enforces category filters and 3-latest rule on home.
+4. Playback requests return stream URLs and caption metadata (localized when available). Download requests ensure policy compliance.
+5. Moderation proposals flow through dedicated endpoints with audit logging.
+
+## Performance & Scaling
+- Target 200 RPS sustained on backend with autoscaling (Kubernetes future). Redis reduces list query latency to <50ms.
+- Database indexing on ytId, category relationships, publishedAt for sorting.
+- Image assets served via CloudFront-like CDN to minimize cold start downloads.
+- Android caches responses using Room + Paging 3 to minimize network calls.
+
+## Deployment & Ops
+- Docker Compose for local dev: services for backend, Postgres, Redis (see future `/ops/docker-compose.yml`).
+- CI/CD: GitHub Actions building backend (Gradle), admin (Vite), Android (Gradle). Automated tests with Testcontainers for backend integration.
+- Environments: dev, staging, prod with separate Redis namespaces and JWT signing keys stored in secrets manager.
+
+## Traceability
+- OpenAPI endpoints cross-referenced in [`../api/openapi-draft.yaml`](../api/openapi-draft.yaml).
+- Security decisions documented in [`../security/threat-model.md`](../security/threat-model.md).
+- Performance budgets and SLIs recorded in [`../testing/test-strategy.md`](../testing/test-strategy.md#performance-metrics).

--- a/docs/backlog/product-backlog.csv
+++ b/docs/backlog/product-backlog.csv
@@ -1,0 +1,20 @@
+Epic,Story ID,Story Title,Description,Estimate (d),Phase
+Vision,DISC-01,Document mission & success metrics,"Finalize vision in docs/vision/vision.md",1,0
+Architecture,ARCH-01,Publish C4 diagrams,"Complete context/container/component diagrams",2,0
+Architecture,ARCH-02,Define security architecture,"Detail JWT, RBAC, rate limits in solution-architecture.md",2,1
+Backend,BACK-01,Implement Auth & JWT rotation,"Build login/refresh/logout endpoints with blacklist",5,1
+Backend,BACK-02,Seed categories via Flyway,"Create baseline categories in migration",2,1
+Backend,BACK-03,Implement cursor pagination,"Add cursor service covering all list endpoints",4,2
+Moderation,MOD-01,Moderation proposal workflow,"Approve/reject endpoints with audit logging",5,2
+Admin UI,ADMIN-01,Admin shell & auth,"Bootstrap Vue app with login & protected routes",4,3
+Admin UI,ADMIN-02,Registry tables,"Channel/Playlist/Video tables with cursor pagination",5,3
+Admin UI,ADMIN-03,Exclusions editor,"UI to manage exclusions, validations",4,4
+Admin UI,ADMIN-04,Audit viewer,"Paginated audit log with filters",3,4
+Android,AND-01,Navigation skeleton,"Implement splash, onboarding, bottom nav per spec",5,5
+Android,AND-02,Category filter state,"Global category filter persisted across tabs",3,6
+Android,AND-03,Channel tabs,"Implement Videos/Live/Shorts/Playlists/Posts tabs",5,7
+Android,AND-04,Player core,"Integrate ExoPlayer with audio-only toggle",6,8
+Android,AND-05,Downloads manager,"Foreground service with queue, notifications",7,9
+Quality,QA-01,Performance benchmarking,"Automate home feed & cold start benchmarks",4,10
+Quality,QA-02,Localization audit,"Run en/ar/nl QA checklist",3,11
+Launch,LAUNCH-01,Beta rollout plan,"Define telemetry, crash reporting, release gating",2,12

--- a/docs/data/json-schemas/admin-search-response.json
+++ b/docs/data/json-schemas/admin-search-response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AdminSearchResponse",
+  "type": "object",
+  "required": ["kind", "results"],
+  "properties": {
+    "kind": { "type": "string", "enum": ["CHANNEL", "PLAYLIST", "VIDEO"] },
+    "results": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "channel-summary.json" },
+          { "$ref": "playlist-summary.json" },
+          { "$ref": "video-summary.json" }
+        ]
+      }
+    }
+  }
+}

--- a/docs/data/json-schemas/admin-user-create-request.json
+++ b/docs/data/json-schemas/admin-user-create-request.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AdminUserCreateRequest",
+  "type": "object",
+  "required": ["email", "password", "roles"],
+  "properties": {
+    "email": { "type": "string", "format": "email", "maxLength": 190 },
+    "password": { "type": "string", "minLength": 12, "maxLength": 128 },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["ADMIN", "MODERATOR"] }
+    }
+  }
+}

--- a/docs/data/json-schemas/admin-user-response.json
+++ b/docs/data/json-schemas/admin-user-response.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AdminUser",
+  "type": "object",
+  "required": ["id", "email", "roles", "status", "createdAt", "updatedAt"],
+  "properties": {
+    "id": { "type": "string" },
+    "email": { "type": "string", "format": "email" },
+    "roles": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["ADMIN", "MODERATOR"] }
+    },
+    "status": { "type": "string", "enum": ["ACTIVE", "DISABLED"] },
+    "lastLoginAt": { "type": ["string", "null"], "format": "date-time" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/data/json-schemas/admin-user-update-request.json
+++ b/docs/data/json-schemas/admin-user-update-request.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AdminUserUpdateRequest",
+  "type": "object",
+  "properties": {
+    "email": { "type": "string", "format": "email", "maxLength": 190 },
+    "password": { "type": "string", "minLength": 12, "maxLength": 128 },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["ADMIN", "MODERATOR"] }
+    },
+    "status": { "type": "string", "enum": ["ACTIVE", "DISABLED"] }
+  },
+  "additionalProperties": false
+}

--- a/docs/data/json-schemas/admin-users-page.json
+++ b/docs/data/json-schemas/admin-users-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AdminUsersPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "admin-user-response.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/audit-entry.json
+++ b/docs/data/json-schemas/audit-entry.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AuditEntry",
+  "type": "object",
+  "required": ["id", "actor", "action", "entity", "metadata", "createdAt"],
+  "properties": {
+    "id": { "type": "string" },
+    "actor": { "$ref": "admin-user-response.json" },
+    "action": { "type": "string" },
+    "entity": {
+      "type": "object",
+      "required": ["type", "id"],
+      "properties": {
+        "type": { "type": "string" },
+        "id": { "type": "string" },
+        "slug": { "type": ["string", "null"] }
+      }
+    },
+    "metadata": { "type": "object", "additionalProperties": true },
+    "createdAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/data/json-schemas/audit-page.json
+++ b/docs/data/json-schemas/audit-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AuditPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "audit-entry.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/auth-login-request.json
+++ b/docs/data/json-schemas/auth-login-request.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AuthLoginRequest",
+  "type": "object",
+  "required": ["email", "password"],
+  "properties": {
+    "email": { "type": "string", "format": "email", "maxLength": 190 },
+    "password": { "type": "string", "minLength": 8, "maxLength": 128 }
+  }
+}

--- a/docs/data/json-schemas/auth-login-response.json
+++ b/docs/data/json-schemas/auth-login-response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AuthLoginResponse",
+  "type": "object",
+  "required": ["accessToken", "refreshToken", "expiresIn", "refreshExpiresIn", "roles"],
+  "properties": {
+    "accessToken": { "type": "string" },
+    "refreshToken": { "type": "string" },
+    "expiresIn": { "type": "integer", "description": "Seconds until access token expiry" },
+    "refreshExpiresIn": { "type": "integer" },
+    "roles": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["ADMIN", "MODERATOR"] }
+    }
+  }
+}

--- a/docs/data/json-schemas/auth-refresh-request.json
+++ b/docs/data/json-schemas/auth-refresh-request.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AuthRefreshRequest",
+  "type": "object",
+  "required": ["refreshToken"],
+  "properties": {
+    "refreshToken": { "type": "string" }
+  }
+}

--- a/docs/data/json-schemas/category-create-request.json
+++ b/docs/data/json-schemas/category-create-request.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CategoryCreateRequest",
+  "type": "object",
+  "required": ["slug", "name"],
+  "properties": {
+    "slug": { "type": "string", "pattern": "^[a-z0-9-]{2,40}$" },
+    "name": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "en": { "type": "string", "maxLength": 80 }
+      },
+      "additionalProperties": { "type": "string", "maxLength": 80 }
+    },
+    "description": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "maxLength": 240 }
+    }
+  }
+}

--- a/docs/data/json-schemas/category-page.json
+++ b/docs/data/json-schemas/category-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CategoryPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "category-response.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/category-response.json
+++ b/docs/data/json-schemas/category-response.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Category",
+  "type": "object",
+  "required": ["id", "slug", "name", "createdAt", "updatedAt"],
+  "properties": {
+    "id": { "type": "string" },
+    "slug": { "type": "string", "pattern": "^[a-z0-9-]{2,40}$" },
+    "name": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "maxLength": 80 },
+      "description": "Map of locale code to localized name"
+    },
+    "description": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "maxLength": 240 }
+    },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/data/json-schemas/category-tag.json
+++ b/docs/data/json-schemas/category-tag.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CategoryTag",
+  "type": "object",
+  "required": ["id", "label"],
+  "properties": {
+    "id": { "type": "string" },
+    "label": { "type": "string" }
+  }
+}

--- a/docs/data/json-schemas/category-update-request.json
+++ b/docs/data/json-schemas/category-update-request.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CategoryUpdateRequest",
+  "type": "object",
+  "properties": {
+    "slug": { "type": "string", "pattern": "^[a-z0-9-]{2,40}$" },
+    "name": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "type": "string", "maxLength": 80 }
+    },
+    "description": {
+      "type": "object",
+      "additionalProperties": { "type": "string", "maxLength": 240 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/data/json-schemas/channel-detail.json
+++ b/docs/data/json-schemas/channel-detail.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ChannelDetail",
+  "allOf": [
+    { "$ref": "channel-summary.json" },
+    {
+      "type": "object",
+      "required": ["description", "videoCount", "liveCount", "shortsCount", "playlistsCount", "postsCount", "links"],
+      "properties": {
+        "description": { "type": ["string", "null"], "maxLength": 2000 },
+        "videoCount": { "type": "integer", "minimum": 0 },
+        "liveCount": { "type": "integer", "minimum": 0 },
+        "shortsCount": { "type": "integer", "minimum": 0 },
+        "playlistsCount": { "type": "integer", "minimum": 0 },
+        "postsCount": { "type": "integer", "minimum": 0 },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["label", "url"],
+            "properties": {
+              "label": { "type": "string" },
+              "url": { "type": "string", "format": "uri" }
+            }
+          }
+        },
+        "lastSyncedAt": { "type": "string", "format": "date-time" }
+      }
+    }
+  ]
+}

--- a/docs/data/json-schemas/channel-page.json
+++ b/docs/data/json-schemas/channel-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ChannelPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "channel-summary.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/channel-summary.json
+++ b/docs/data/json-schemas/channel-summary.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ChannelSummary",
+  "type": "object",
+  "required": ["id", "ytId", "name", "avatarUrl", "subscriberCount", "categories"],
+  "properties": {
+    "id": { "type": "string" },
+    "ytId": { "type": "string" },
+    "name": { "type": "string" },
+    "avatarUrl": { "type": "string", "format": "uri" },
+    "subscriberCount": { "type": "integer", "minimum": 0 },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "category-tag.json" }
+    }
+  }
+}

--- a/docs/data/json-schemas/cursor-page-info.json
+++ b/docs/data/json-schemas/cursor-page-info.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CursorPageInfo",
+  "type": "object",
+  "required": ["cursor", "nextCursor", "hasNext"],
+  "properties": {
+    "cursor": { "type": ["string", "null"], "description": "Cursor of current page" },
+    "nextCursor": { "type": ["string", "null"] },
+    "hasNext": { "type": "boolean" },
+    "limit": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/docs/data/json-schemas/error-response.json
+++ b/docs/data/json-schemas/error-response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ErrorResponse",
+  "type": "object",
+  "required": ["error", "message", "timestamp"],
+  "properties": {
+    "error": { "type": "string" },
+    "message": { "type": "string" },
+    "details": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "traceId": { "type": ["string", "null"] }
+  }
+}

--- a/docs/data/json-schemas/exclusion-create-request.json
+++ b/docs/data/json-schemas/exclusion-create-request.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ExclusionCreateRequest",
+  "type": "object",
+  "required": ["parentType", "parentId", "excludeType", "excludeId", "reason"],
+  "properties": {
+    "parentType": { "type": "string", "enum": ["CHANNEL", "PLAYLIST"] },
+    "parentId": { "type": "string" },
+    "excludeType": { "type": "string", "enum": ["VIDEO", "PLAYLIST"] },
+    "excludeId": { "type": "string" },
+    "reason": { "type": "string", "maxLength": 500 }
+  }
+}

--- a/docs/data/json-schemas/exclusion-response.json
+++ b/docs/data/json-schemas/exclusion-response.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Exclusion",
+  "type": "object",
+  "required": ["id", "parentType", "parentId", "excludeType", "excludeId", "reason", "createdAt", "createdBy"],
+  "properties": {
+    "id": { "type": "string" },
+    "parentType": { "type": "string", "enum": ["CHANNEL", "PLAYLIST"] },
+    "parentId": { "type": "string" },
+    "excludeType": { "type": "string", "enum": ["VIDEO", "PLAYLIST"] },
+    "excludeId": { "type": "string" },
+    "reason": { "type": "string" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "createdBy": { "$ref": "admin-user-response.json" }
+  }
+}

--- a/docs/data/json-schemas/home-response.json
+++ b/docs/data/json-schemas/home-response.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HomeResponse",
+  "type": "object",
+  "required": ["cursor", "sections"],
+  "properties": {
+    "cursor": { "$ref": "cursor-page-info.json" },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "title", "items"],
+        "properties": {
+          "type": { "type": "string", "enum": ["CHANNELS", "PLAYLISTS", "VIDEOS"] },
+          "title": { "type": "string" },
+          "items": {
+            "type": "array",
+            "maxItems": 3,
+            "items": {
+              "oneOf": [
+                { "$ref": "channel-summary.json" },
+                { "$ref": "playlist-summary.json" },
+                { "$ref": "video-summary.json" }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/data/json-schemas/live-page.json
+++ b/docs/data/json-schemas/live-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LivePage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "live-session-summary.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/live-session-summary.json
+++ b/docs/data/json-schemas/live-session-summary.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LiveSessionSummary",
+  "type": "object",
+  "required": ["id", "ytId", "title", "thumbnailUrl", "scheduledStartAt", "channel", "categories", "status"],
+  "properties": {
+    "id": { "type": "string" },
+    "ytId": { "type": "string" },
+    "title": { "type": "string" },
+    "thumbnailUrl": { "type": "string", "format": "uri" },
+    "scheduledStartAt": { "type": "string", "format": "date-time" },
+    "status": { "type": "string", "enum": ["SCHEDULED", "LIVE", "ENDED"] },
+    "channel": { "$ref": "channel-summary.json" },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "category-tag.json" }
+    }
+  }
+}

--- a/docs/data/json-schemas/moderation-proposal-create-request.json
+++ b/docs/data/json-schemas/moderation-proposal-create-request.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ModerationProposalCreateRequest",
+  "type": "object",
+  "required": ["kind", "ytId", "suggestedCategories"],
+  "properties": {
+    "kind": { "type": "string", "enum": ["CHANNEL", "PLAYLIST", "VIDEO"] },
+    "ytId": { "type": "string", "maxLength": 64 },
+    "suggestedCategories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "notes": { "type": ["string", "null"], "maxLength": 1000 }
+  }
+}

--- a/docs/data/json-schemas/moderation-proposal-page.json
+++ b/docs/data/json-schemas/moderation-proposal-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ModerationProposalPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "moderation-proposal-response.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/moderation-proposal-reject-request.json
+++ b/docs/data/json-schemas/moderation-proposal-reject-request.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ModerationProposalRejectRequest",
+  "type": "object",
+  "properties": {
+    "reason": { "type": "string", "maxLength": 500 }
+  },
+  "additionalProperties": false
+}

--- a/docs/data/json-schemas/moderation-proposal-response.json
+++ b/docs/data/json-schemas/moderation-proposal-response.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ModerationProposal",
+  "type": "object",
+  "required": ["id", "kind", "ytId", "status", "suggestedCategories", "proposer", "createdAt", "decidedBy", "decidedAt"],
+  "properties": {
+    "id": { "type": "string" },
+    "kind": { "type": "string", "enum": ["CHANNEL", "PLAYLIST", "VIDEO"] },
+    "ytId": { "type": "string" },
+    "status": { "type": "string", "enum": ["PENDING", "APPROVED", "REJECTED"] },
+    "suggestedCategories": {
+      "type": "array",
+      "items": { "$ref": "category-tag.json" }
+    },
+    "proposer": { "$ref": "admin-user-response.json" },
+    "notes": { "type": ["string", "null"] },
+    "decidedBy": { "$ref": "admin-user-response.json" },
+    "decidedAt": { "type": ["string", "null"], "format": "date-time" },
+    "createdAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/data/json-schemas/playlist-detail.json
+++ b/docs/data/json-schemas/playlist-detail.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PlaylistDetail",
+  "allOf": [
+    { "$ref": "playlist-summary.json" },
+    {
+      "type": "object",
+      "required": ["description", "durationSeconds", "downloadPolicy", "lastSyncedAt"],
+      "properties": {
+        "description": { "type": ["string", "null"], "maxLength": 4000 },
+        "durationSeconds": { "type": "integer", "minimum": 0 },
+        "downloadPolicy": { "type": "string", "enum": ["ENABLED", "DISABLED_BY_POLICY"] },
+        "lastSyncedAt": { "type": "string", "format": "date-time" }
+      }
+    }
+  ]
+}

--- a/docs/data/json-schemas/playlist-page.json
+++ b/docs/data/json-schemas/playlist-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PlaylistPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "playlist-summary.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/playlist-summary.json
+++ b/docs/data/json-schemas/playlist-summary.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PlaylistSummary",
+  "type": "object",
+  "required": ["id", "ytId", "title", "thumbnailUrl", "itemCount", "owner", "categories"],
+  "properties": {
+    "id": { "type": "string" },
+    "ytId": { "type": "string" },
+    "title": { "type": "string" },
+    "thumbnailUrl": { "type": "string", "format": "uri" },
+    "itemCount": { "type": "integer", "minimum": 0 },
+    "owner": { "$ref": "channel-summary.json" },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "category-tag.json" }
+    },
+    "downloadable": { "type": "boolean", "default": true }
+  }
+}

--- a/docs/data/json-schemas/post-page.json
+++ b/docs/data/json-schemas/post-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PostPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "post-summary.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/post-summary.json
+++ b/docs/data/json-schemas/post-summary.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ChannelPostSummary",
+  "type": "object",
+  "required": ["id", "ytId", "content", "publishedAt", "attachments"],
+  "properties": {
+    "id": { "type": "string" },
+    "ytId": { "type": "string" },
+    "content": { "type": "string", "maxLength": 5000 },
+    "publishedAt": { "type": "string", "format": "date-time" },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": { "type": "string", "enum": ["IMAGE", "POLL", "LINK"] },
+          "url": { "type": ["string", "null"], "format": "uri" },
+          "text": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/docs/data/json-schemas/video-detail.json
+++ b/docs/data/json-schemas/video-detail.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VideoDetail",
+  "allOf": [
+    { "$ref": "video-summary.json" },
+    {
+      "type": "object",
+      "required": ["description", "captions", "qualities", "audioOnly", "downloadPolicy", "chapters"],
+      "properties": {
+        "description": { "type": ["string", "null"], "maxLength": 5000 },
+        "captions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["locale", "url"],
+            "properties": {
+              "locale": { "type": "string" },
+              "url": { "type": "string", "format": "uri" },
+              "label": { "type": "string" }
+            }
+          }
+        },
+        "qualities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["itag", "label", "bitrate", "mimeType"],
+            "properties": {
+              "itag": { "type": "integer" },
+              "label": { "type": "string" },
+              "bitrate": { "type": "integer" },
+              "mimeType": { "type": "string" }
+            }
+          }
+        },
+        "audioOnly": {
+          "type": "object",
+          "required": ["itag", "bitrate", "mimeType", "url"],
+          "properties": {
+            "itag": { "type": "integer" },
+            "bitrate": { "type": "integer" },
+            "mimeType": { "type": "string" },
+            "url": { "type": "string", "format": "uri" }
+          }
+        },
+        "downloadPolicy": { "type": "string", "enum": ["ENABLED", "DISABLED_BY_POLICY"] },
+        "chapters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["title", "offsetSeconds"],
+            "properties": {
+              "title": { "type": "string" },
+              "offsetSeconds": { "type": "integer", "minimum": 0 }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/data/json-schemas/video-page.json
+++ b/docs/data/json-schemas/video-page.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VideoPage",
+  "type": "object",
+  "required": ["data", "pageInfo"],
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": { "$ref": "video-summary.json" }
+    },
+    "pageInfo": { "$ref": "cursor-page-info.json" }
+  }
+}

--- a/docs/data/json-schemas/video-summary.json
+++ b/docs/data/json-schemas/video-summary.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VideoSummary",
+  "type": "object",
+  "required": ["id", "ytId", "title", "thumbnailUrl", "durationSeconds", "publishedAt", "viewCount", "channel", "categories"],
+  "properties": {
+    "id": { "type": "string" },
+    "ytId": { "type": "string" },
+    "title": { "type": "string" },
+    "thumbnailUrl": { "type": "string", "format": "uri" },
+    "durationSeconds": { "type": "integer", "minimum": 0 },
+    "publishedAt": { "type": "string", "format": "date-time" },
+    "viewCount": { "type": "integer", "minimum": 0 },
+    "channel": { "$ref": "channel-summary.json" },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "category-tag.json" }
+    },
+    "bookmarked": { "type": "boolean" },
+    "downloaded": { "type": "boolean" }
+  }
+}

--- a/docs/i18n/strategy.md
+++ b/docs/i18n/strategy.md
@@ -1,0 +1,48 @@
+# Internationalization Strategy
+
+This strategy covers localization for English (`en`), Modern Standard Arabic (`ar`), and Dutch (`nl`). It aligns with UI specs in [`../ux/ui-spec.md`](../ux/ui-spec.md) and API contracts in [`../api/openapi-draft.yaml`](../api/openapi-draft.yaml).
+
+## Localization Model
+- User-facing strings stored as ICU MessageFormat entries.
+- Keys follow `feature.scope.message` naming (e.g., `home.section.channels`).
+- Admin-managed content (titles, descriptions) stored as `{ locale: string }` maps in the database (see [`../data/json-schemas`](../data/json-schemas)).
+- Backend resolves `Accept-Language` header with fallback order: requested locale → `en`.
+- Android uses string resources with `values/`, `values-ar/`, `values-nl/`; fonts include Arabic shaping support (Noto Naskh Arabic).
+- Admin SPA uses `vue-i18n` with lazy-loaded locale chunks; fallback to English.
+
+## Pluralization & ICU
+- Use ICU plurals for counts (`{count, plural, one {...} other {...}}`) respecting each locale's rules (Arabic has 6 plural forms).
+- Date/time formatting via `Intl.DateTimeFormat` on web and `java.time` on backend/Android with locale-specific numerals.
+- Dynamic inserts sanitized (no HTML injection).
+
+## RTL Support
+- Android enables `android:supportsRtl="true"`; ensure mirrored assets for directional icons (back, forward, download). Layouts tested with `ViewCompat.setLayoutDirection`.
+- Admin SPA uses CSS logical properties (`margin-inline-start`).
+- Player controls mirror order for RTL (Audio toggle near left). See [`../ux/ui-spec.md`](../ux/ui-spec.md#accessibility--localization).
+
+## Locale Detection & Switching
+- Android: on first launch detect via `LocaleListCompat.getAdjustedDefault()`. Prompt user with onboarding to confirm; store preference in DataStore. Provide in-app locale switcher (Settings) with immediate restart of activity.
+- Admin SPA: read `Accept-Language`; allow manual switcher in header; persist in localStorage.
+- Backend: Accepts `X-Admin-Locale` override for admin operations when editing localized fields.
+
+## Content Entry Workflow
+1. Admin searches YouTube via `/admin/search` (see [`../api/openapi-draft.yaml`](../api/openapi-draft.yaml#paths-/admin/search)).
+2. On approval, admin enters localized metadata for en/ar/nl. UI enforces at least English and one additional translation.
+3. Validation ensures strings ≤ defined lengths (see schemas).
+4. Audit log captures locale changes.
+
+## QA Guidelines
+- **Truncation**: Validate key screens with longest translations; ensure 20% text expansion tolerance.
+- **BiDi**: Test Arabic strings with embedded English numbers; ensure correct direction via Unicode control characters where needed.
+- **Numerals**: Use locale digits for durations and counts; Arabic uses Eastern Arabic numerals (via `NumberFormat`).
+- **Input**: Admin forms allow RTL input with text alignment toggles.
+- **Regression**: Run pseudo-localization (accented English) before string freeze.
+
+## Localization Tooling
+- Manage strings in a shared spreadsheet/export pipeline producing JSON for admin and XML for Android.
+- Use `crowdin` or `lokalise` for translation management; include context screenshots (see UI spec).
+- CI step verifies keys across platforms (no missing translations).
+
+## Traceability
+- Requirements tracked in Phase 11 plan (see [`../roadmap/roadmap.md`](../roadmap/roadmap.md)).
+- Acceptance criteria for localization in [`../acceptance/criteria.md`](../acceptance/criteria.md#internationalization).

--- a/docs/risk-register.md
+++ b/docs/risk-register.md
@@ -1,0 +1,13 @@
+# Risk Register
+
+| ID | Risk | Impact | Likelihood | Owner | Mitigation | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| RSK-001 | YouTube API changes break NewPipeExtractor | High | Medium | Principal Engineer | Monitor upstream releases; maintain fork; build fallback metadata cache. | Open |
+| RSK-002 | Localization quality issues in Arabic shaping | Medium | Medium | Localization Lead | Adopt Noto fonts, run pseudo-localization, include Arabic QA early. | Open |
+| RSK-003 | Legal challenge for offline downloads | High | Low | Product Lead | Secure legal review, provide EULA, enforce download policy flag. | Open |
+| RSK-004 | Moderator backlog exceeding SLA | Medium | Medium | Moderation Lead | Add alerts for >12h pending, scale staffing, implement bulk actions. | Open |
+| RSK-005 | Performance degradation on low-end devices | Medium | Medium | Android Lead | Profile using Macrobenchmark, optimize image caching (Coil), enforce 80KB payload budget. | Open |
+| RSK-006 | Security breach via stolen refresh token | High | Low | Security Lead | Device binding, refresh rotation, anomaly detection, revoke tokens. | Open |
+| RSK-007 | Redis outage causing API latency | Medium | Low | DevOps Lead | Implement cache fallback with circuit breaker, monitor with Prometheus alerts. | Open |
+
+Risks map to mitigation tasks in [`docs/backlog/product-backlog.csv`](backlog/product-backlog.csv) and security controls in [`docs/security/threat-model.md`](security/threat-model.md).

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,0 +1,27 @@
+# Phased Roadmap
+
+This roadmap aligns with the phased deliverables outlined in the program brief. Each phase lists objectives, key artifacts (with repo links), and exit criteria.
+
+| Phase | Objective | Key Deliverables | Exit Criteria |
+| --- | --- | --- | --- |
+| 0 — Discovery & Contracts | Establish product vision, architecture outline, UX contract, localization approach. | - [`docs/vision/vision.md`](../vision/vision.md) <br> - [`docs/api/openapi-draft.yaml`](../api/openapi-draft.yaml) <br> - [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md) <br> - [`docs/ux/ui-spec.md`](../ux/ui-spec.md) <br> - [`docs/i18n/strategy.md`](../i18n/strategy.md) | Stakeholder sign-off on scope and contracts. |
+| 1 — Backend Foundations | Plan authentication, RBAC, schema baseline, migrations, seeds. | - Auth/RBAC implementation plan (see [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md#security-architecture)) <br> - Testing approach (see [`docs/testing/test-strategy.md`](../testing/test-strategy.md)) | Engineering backlog for Auth/Categories ready. |
+| 2 — Registry & Moderation | Finalize domain model, pagination, caching, moderation flows. | - Data model schematics (see [`docs/data/json-schemas`](../data/json-schemas)) <br> - Moderation sequence diagram (see [`docs/architecture/diagrams/moderation-sequence.md`](../architecture/diagrams/moderation-sequence.md)) | Tickets with acceptance criteria approved. |
+| 3 — Admin UI MVP | IA, routing, state, localization wiring for admin console. | - Admin UI flows (see [`docs/ux/ui-spec.md`](../ux/ui-spec.md#admin-flows)) <br> - Task list in [`docs/backlog/product-backlog.csv`](../backlog/product-backlog.csv) | MVP scope frozen and estimated. |
+| 4 — Admin UI Complete | Add exclusions editor, user management, audit viewer, a11y polish. | - Updated backlog stories <br> - Accessibility guidelines (see [`docs/ux/ui-spec.md`](../ux/ui-spec.md#accessibility)) | Feature-complete admin console spec. |
+| 5 — Android Skeleton | Navigation graph, onboarding, bottom nav, category sheet, locale switch. | - Android architecture plan (see [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md#android-architecture)) <br> - Screen specs (see [`docs/ux/ui-spec.md`](../ux/ui-spec.md#android-screens)) | UI kit approved. |
+| 6 — Lists & Home Rules | Paging, “3-latest” logic, error handling. | - Paging contract (see [`docs/api/openapi-draft.yaml`](../api/openapi-draft.yaml#components-schemas-CursorPagination)) <br> - Test cases (see [`docs/testing/test-strategy.md`](../testing/test-strategy.md#android-client)) | QA checklist ready. |
+| 7 — Channel/Playlist Details | Tab behaviors, deep links, exclusions enforcement. | - Sequence diagrams (see [`docs/architecture/diagrams/channel-tabs-sequence.md`](../architecture/diagrams/channel-tabs-sequence.md)) | Test matrix in [`docs/testing/test-strategy.md`](../testing/test-strategy.md). |
+| 8 — Player & Background Audio | ExoPlayer, PiP, captions, quality selector, background controls. | - Media session plan (see [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md#playback-engine)) | Reliability scenarios documented. |
+| 9 — Downloads & Offline | Queue, notifications, policy gating, storage quotas. | - Offline policy (see [`docs/security/threat-model.md`](../security/threat-model.md#policy-controls)) <br> - Storage strategy in [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md#offline-downloads) | Storage & policy checklist complete. |
+| 10 — Perf & Security Hardening | Caching, performance budgets, pen-test prep. | - Perf plan (see [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md#performance)) <br> - Security checklist (see [`docs/security/threat-model.md`](../security/threat-model.md#controls)) | Sign-off by security & performance leads. |
+| 11 — i18n & Accessibility Polish | Localization QA, bidi, numeral handling, TalkBack. | - Localization QA guide (see [`docs/i18n/strategy.md`](../i18n/strategy.md#qa-guidelines)) | Compliance report delivered. |
+| 12 — Beta & Launch | Telemetry, crash reporting, rollout & rollback plan. | - Launch checklist (see [`docs/testing/test-strategy.md`](../testing/test-strategy.md#release-management)) | Go-live approval. |
+
+## Dependencies & Milestones
+- Phase 1 depends on Phase 0 sign-off.
+- Android Phases (5–9) depend on backend API stability from Phases 1–2.
+- Localization polish (Phase 11) requires UI text freeze.
+- Launch (Phase 12) depends on prior phase exit criteria being met.
+
+See [`docs/backlog/product-backlog.csv`](../backlog/product-backlog.csv) for story-level planning.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,47 @@
+# Threat Model & Security Controls
+
+This document applies STRIDE analysis to Albunyaan Tube and enumerates required mitigations. Refer to [`../architecture/solution-architecture.md`](../architecture/solution-architecture.md#security-architecture) for structural context and [`../testing/test-strategy.md`](../testing/test-strategy.md#security-testing) for validation plans.
+
+## Assets
+- Allow-listed content registry (channels, playlists, videos).
+- Admin accounts and JWT tokens.
+- Audit logs and moderation decisions.
+- Downloaded media (policy-restricted).
+- Localization strings and halal policy metadata.
+
+## STRIDE Analysis
+| Threat | Surface | Impact | Mitigation |
+| --- | --- | --- | --- |
+| **Spoofing** | JWT authentication, admin login | Unauthorized access to moderation | Spring Security with Argon2id password hashing, JWT signing keys stored in HSM/Secrets Manager, refresh token rotation + device binding. |
+| **Tampering** | Registry mutations, Flyway migrations | Corruption of allow-list | Role-based access (ADMIN/MODERATOR), validation via JSON Schemas, Flyway checksum enforcement, immutable audit trail with append-only table. |
+| **Repudiation** | Moderation approvals/rejections | Disputed actions | Audit logging for all POST/PUT/DELETE, including IP/device metadata; logs retained 7 years. |
+| **Information Disclosure** | Download URLs, user emails | Leakage of private links | Signed stream URLs expire within 5 minutes; downloads require policy flag `ENABLED`; TLS 1.2+, secrets rotated quarterly. |
+| **Denial of Service** | API rate abuse, cache stampede | Service degradation | Redis-based sliding window rate limiting (per IP + account), circuit breakers for NewPipeExtractor, autoscaling thresholds, backpressure in Paging 3. |
+| **Elevation of Privilege** | Privilege escalation via JWT | Gain ADMIN rights | JWT contains role claim validated against DB; refresh rotation invalidates previous token; Redis blacklist for revoked tokens; periodic permission audits (monthly). |
+
+## Additional Controls
+- **CSRF**: Admin SPA uses double-submit cookie for state-changing requests; backend validates tokens.
+- **Input Validation**: Bean Validation + JSON Schema alignment; slug patterns enforced.
+- **Transport Security**: Enforce HTTPS (HSTS), disable TLS <1.2.
+- **Secrets Handling**: Use Vault/SM for DB creds, JWT secrets; never commit secrets.
+- **Dependency Management**: OWASP Dependency-Check in CI; SLSA provenance targets.
+- **Rate Limits**: Default 60 req/min per user for write endpoints; 600 req/min per IP for read.
+- **Token Storage**: Admin SPA stores access token in memory, refresh token as HTTP-only secure cookie.
+- **Audit Log Integrity**: Use write-only Postgres table with partitioning; daily export to immutable storage (S3 with Object Lock).
+- **Download Policy Enforcement**: Backend verifies `downloadPolicy=ENABLED` before issuing download manifest; offline EULA acceptance recorded per device.
+- **Data Retention**: Prune audit logs >7 years; purge inactive downloads after 30 days.
+
+## Incident Response
+1. Detect via monitoring (Prometheus alerts, ELK).
+2. Contain by revoking JWT signing keys (rotate) and disabling affected accounts.
+3. Eradicate threat by patching vulnerability, running malware scans on servers.
+4. Recover by redeploying clean images (immutable infrastructure).
+5. Post-incident review logged in audit system and backlog.
+
+## Compliance
+- Align with Islamic content governance board decisions.
+- GDPR considerations: store minimal personal data (admin emails); provide account deletion within 30 days.
+- Offline media rights: enforce EULA acceptance, expose policy in-app (see [`../acceptance/criteria.md`](../acceptance/criteria.md#downloads-and-offline)).
+
+## Traceability
+Security requirements map to acceptance scenarios in [`../acceptance/criteria.md`](../acceptance/criteria.md#security) and test strategy coverage in [`../testing/test-strategy.md`](../testing/test-strategy.md#security-testing).

--- a/docs/testing/test-strategy.md
+++ b/docs/testing/test-strategy.md
@@ -1,0 +1,56 @@
+# Test Strategy
+
+This strategy spans backend, admin frontend, and Android client. It complements the architecture plan in [`../architecture/solution-architecture.md`](../architecture/solution-architecture.md) and acceptance criteria in [`../acceptance/criteria.md`](../acceptance/criteria.md).
+
+## Guiding Principles
+- Automated coverage for every acceptance criterion prior to release.
+- Use real dependencies via Testcontainers for backend persistence.
+- Localized fixtures for en/ar/nl to verify translations.
+- Security regression tests enforce JWT rotation, blacklist, and RBAC.
+
+## Backend Testing
+| Layer | Tooling | Scope |
+| --- | --- | --- |
+| Unit | JUnit 5, Mockito | Service-level logic (3-latest rule, pagination parsing, download policy enforcement). |
+| Integration | Spring Boot Test + Testcontainers (PostgreSQL, Redis) | Auth flows, repository queries, caching invalidation, Accept-Language fallbacks. |
+| Contract | Spring Cloud Contract / OpenAPI schema validation | Ensure responses match schemas in [`../data/json-schemas`](../data/json-schemas). |
+| Performance | Gatling | Verify list endpoints deliver ≤80KB payload per page and <150ms server time at 200 RPS. |
+| Security | OWASP ZAP, dependency scanning | Check for common vulnerabilities, enforce TLS. |
+
+### Error Taxonomy
+- `CLIENT_ERROR` (4xx) with localization.
+- `SERVER_ERROR` (5xx) with traceId.
+- `POLICY_BLOCK` for download-disabled scenarios.
+
+## Admin Frontend Testing
+- **Unit**: Vitest for components; ensure tokens from [`../ux/design-tokens.json`](../ux/design-tokens.json) applied.
+- **E2E**: Playwright hitting staging backend mock; scenarios include moderation approval, exclusions editing, audit pagination.
+- **i18n**: Snapshot tests verifying ar/nl translations, directionality (RTL snapshots).
+- **Accessibility**: axe-core integration ensures WCAG AA.
+
+## Android Testing
+- **Unit**: JUnit + Mockito for ViewModels/use cases.
+- **Instrumentation**: Espresso for navigation flows (onboarding, bottom nav, filters).
+- **Playback Reliability** (Phase 8): Robolectric for state, device farm for PiP/background audio scenarios.
+- **Paging**: Paging 3 test helpers verifying cursor handoff.
+- **Download Service**: WorkManager test harness to validate pause/resume, quota enforcement.
+- **Localization**: Locale-specific screenshot tests using Paparazzi.
+
+## Test Data Management
+- Seed data via Flyway migrations for categories + sample content (Phase 1 exit criteria).
+- Use synthetic thumbnails stored locally for tests; avoid hitting YouTube.
+- Redact any production data; use environment variables for secrets.
+
+## Observability Validation
+- Assert structured logs contain `traceId`, `userId`, `locale` fields.
+- Metrics tests verify custom counters (`downloads_started`, `moderation_pending`).
+- Alerting runbook stored in ops documentation (future `/ops` folder).
+
+## Release Management
+- Staging environment smoke tests triggered by CI pipeline.
+- Beta rollout gating on crash-free sessions ≥99% (Firebase Crashlytics).
+- Rollback plan: blue/green deployment for backend; Play Store staged rollout for Android.
+
+## Traceability
+- Test cases map to acceptance criteria IDs (see [`../acceptance/criteria.md`](../acceptance/criteria.md)).
+- Performance budgets derived from vision metrics (see [`../vision/vision.md`](../vision/vision.md#success-metrics)).

--- a/docs/ux/design-tokens.json
+++ b/docs/ux/design-tokens.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://design-tokens.org/schemas/1.0/design-tokens.schema.json",
+  "metadata": {
+    "name": "Albunyaan Tube Design Tokens",
+    "version": "0.1.0",
+    "description": "Baseline tokens aligned with Phase 0 mockups."
+  },
+  "group": {
+    "color": {
+      "primary": { "value": "#275E4B" },
+      "background": { "value": "#F6F9F9" },
+      "textPrimary": { "value": "#1F2937" },
+      "textSecondary": { "value": "#6B7280" },
+      "success": { "value": "#0E9F6E" },
+      "surface": { "value": "#FFFFFF" },
+      "surfaceMuted": { "value": "#E4F0EC" },
+      "border": { "value": "#D1D5DB" },
+      "shadow": { "value": "rgba(15, 32, 26, 0.12)" }
+    },
+    "typography": {
+      "fontFamilyPrimary": { "value": "'Inter', 'Roboto', 'Noto Sans Arabic', sans-serif" },
+      "h1": { "value": { "fontSize": "28sp", "fontWeight": 700, "lineHeight": "36sp" } },
+      "h2": { "value": { "fontSize": "22sp", "fontWeight": 600, "lineHeight": "30sp" } },
+      "body": { "value": { "fontSize": "16sp", "fontWeight": 500, "lineHeight": "24sp" } },
+      "caption": { "value": { "fontSize": "13sp", "fontWeight": 500, "lineHeight": "18sp" } }
+    },
+    "elevation": {
+      "card": { "value": "0px 8px 24px rgba(15, 32, 26, 0.08)" },
+      "sheet": { "value": "0px 12px 32px rgba(15, 32, 26, 0.12)" }
+    },
+    "radius": {
+      "large": { "value": "20dp" },
+      "medium": { "value": "16dp" },
+      "small": { "value": "12dp" }
+    },
+    "spacing": {
+      "grid": { "value": "8dp" },
+      "contentMaxWidth": { "value": "640dp" }
+    },
+    "motion": {
+      "durationShort": { "value": "120ms" },
+      "durationMedium": { "value": "200ms" },
+      "easingStandard": { "value": "cubic-bezier(0.4, 0.0, 0.2, 1)" }
+    }
+  }
+}

--- a/docs/ux/ui-spec.md
+++ b/docs/ux/ui-spec.md
@@ -1,0 +1,106 @@
+# UI Specification
+
+This document codifies the canonical UI contract for Albunyaan Tube Android and Admin experiences. It references design tokens in [`design-tokens.json`](design-tokens.json) and aligns with the provided mockups (see attachments `1_splash_screen.png`–`10_player_screen.png`).
+
+## Global Principles
+- Respect the halal curation promise: no comments, ads, or autoplay.
+- Primary color: `#275E4B`; background: `#F6F9F9`; text `#1F2937` / `#6B7280`.
+- Corner radii 16–20dp with subtle shadows (`card` elevation token).
+- Minimum touch target: 48dp.
+- Typography scale: H1 28sp, H2 22sp, Body 16sp, Caption 13sp.
+
+## Layout Grid
+- 8dp baseline grid for spacing.
+- Content max width 640dp (see tokens).
+- Bottom navigation height 72dp, icons 24dp with 8dp label gap.
+
+## Component Library
+| Component | Description | States | Accessibility |
+| --- | --- | --- | --- |
+| Category Chip | Rounded 20dp pill with primary outline. Filled when selected. | Default, Selected, Focused, Disabled. | `role="tab"` semantics, TalkBack label includes locale-aware category name. |
+| List Card | Horizontal card with thumbnail/avatar left, text right. | Default, Loading Skeleton. | Provide content description for thumbnail (channel name). |
+| Grid Card | 16dp radius image top, text bottom. | Default, Skeleton, Downloaded overlay. | Use aspect ratio 16:9; overlay icons with 12dp padding. |
+| Hero Card | Playlist detail hero: 20dp radius, 24dp padding. | Default, Offline available (shows download badge). | Primary heading announced first, then description. |
+| Tabs | Used on Channel detail (Videos/Live/Shorts/Playlists/Posts). | Active indicator 4dp, focus ring 2dp success color. | Support RTL mirroring. |
+| Filter Row | Horizontal chip row with dropdown triggers (Category, Length, Date, Popular). | Default, Expanded (dropdown). | Dropdown uses modal bottom sheet with keyboard navigation support. |
+| Download Button | Primary success button with download icon; 20dp radius. | Idle, Downloading (progress ring), Completed. | Announce download status; long press reveals context menu for remove. |
+| Bookmark Toggle | Heart icon filled when bookmarked. | Off, On, Syncing. | Toggle described as “Bookmark video” / “Remove bookmark”. |
+| Empty State | Centered icon (96dp), headline, body, action button. | Default. | Provide localized instructions. |
+| Skeleton State | Pulsing light-gray placeholders (surfaceMuted). | Default. | Not announced to TalkBack (aria-hidden). |
+
+## Screen Specifications (Android)
+Each screen references the mockups. Layout measurements assume 360dp width baseline.
+
+### Splash (`1_splash_screen.png`)
+- Logo icon 96dp centered vertically with 24dp spacing to tagline.
+- Spinner 32dp diameter, success color accent.
+- Display for ≥1.5s while initialization completes.
+
+### Onboarding (`2_onboarding_screen_1.png`, `3_onboarding_screen_2.png`)
+- Carousel height 320dp, indicator dots 8dp spaced 12dp.
+- Help “?” button top-right (touch target 48dp).
+- CTA button 56dp height, full width minus 24dp margin.
+- Skip CTA text button bottom center.
+
+### Home (`4_home_screen.png`)
+- Header H1 “Albunyaan Tube” left-aligned; actions: Search (24dp icon), Profile (optional future) right-aligned.
+- Category filter chip row horizontally scrollable; default “All”.
+- Sections: Channels, Playlists, Videos each with H2 title and “See all” text button (Body style). Each section shows 3 cards horizontally scrollable with 16dp gutter.
+- Up Next from backend is not present here (only in player).
+
+### Channels Tab (`5_channes_list_screen.png`)
+- List items: avatar 56dp circle, left margin 24dp, 16dp spacing to text.
+- Metadata: subscriber count (Body), category tags (chips) below.
+- Sticky global category filter at top.
+
+### Channel Detail (`6_channel_details_screen.png`)
+- Hero: avatar 96dp, channel name H1, subscriber/video counts Body secondary.
+- Subscribe button: success color, 20dp radius.
+- Tabs across top with 16dp padding; maintain horizontal scroll for overflow.
+- Content area uses grid or list based on tab (Videos grid, Live list, etc.).
+
+### Playlists List (`7_playlist_list_screen.png`)
+- Card height 132dp, image left 40%, text right with Body + Caption for counts.
+- Download badge (success color) for already downloaded playlists.
+
+### Playlist Detail (`8_playlist_details_screen.png`)
+- Hero uses gradient overlay on thumbnail, includes owner info (avatar 32dp, name Body) and description (Body).
+- Download playlist button anchored under hero; success color.
+- Video list inherits list card style with per-item download toggles.
+
+### Videos Tab (`9_all_videos_screen.png`)
+- Filters row pinned under header: Category, Length, Date, Popular dropdowns.
+- Grid: 2 columns, card width 164dp, height 220dp with 16dp gutter.
+- Each card shows length badge top-right, published info Body/Caption.
+
+### Player (`10_player_screen.png`)
+- Video stage 16:9, controls overlay includes CC, HD, settings icons top-right.
+- Below stage: title (Body bold), speaker (Caption), control row (Bookmark, Share, Download, Audio) spaced 16dp.
+- Up Next list shows 3 items with thumbnails 96x54dp, inline play icon overlay.
+- Background audio toggle persists state via shared preferences.
+
+## Admin Console UX (Phase 3+)
+- Navigation sidebar (left) with sections: Dashboard, Registry (Channels, Playlists, Videos), Moderation, Users, Audit.
+- Data tables use sticky headers, column sorting, 16px rows, inline badges for statuses.
+- Forms for categories and content editing use i18n input tabs (en/ar/nl). See [`docs/i18n/strategy.md`](../i18n/strategy.md#admin-ui).
+
+## Accessibility & Localization
+- Contrast ratios ≥4.5:1; ensure success color on white meets 3:1 for large text.
+- Provide TalkBack labels for media controls (e.g., “Audio-only playback”).
+- RTL: mirror layout, align text per locale, swap navigation order. Validate in [`docs/i18n/strategy.md`](../i18n/strategy.md#rtl-support).
+- Numerals: use locale digits in captions/durations (Arabic Indic digits for ar).
+
+## Interaction States
+- Focus rings 2dp success color; maintain for keyboard and remote usage (future TV support).
+- Loading uses skeletons; error states show inline message with retry button.
+- No autoplay after video ends; show static end-screen with replay button.
+
+## Asset Guidelines
+- Channel avatars circular, 1px border `#FFFFFF` to separate from background.
+- Placeholder images use geometric patterns tinted with primary color.
+- Download icons follow Material Symbols style; adjust for RTL mirroring when directional.
+
+## Traceability
+- UI components map to data contracts in [`docs/api/openapi-draft.yaml`](../api/openapi-draft.yaml) (see `VideoSummary`, `ChannelSummary`, `PlaylistSummary`).
+- Acceptance scenarios referencing UI live in [`docs/acceptance/criteria.md`](../acceptance/criteria.md#android-client).
+- Design tokens consumption tracked in Android Phase 5 plan within [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md#design-system-integration).

--- a/docs/vision/vision.md
+++ b/docs/vision/vision.md
@@ -1,0 +1,43 @@
+# Albunyaan Tube Vision & Discovery Summary
+
+## Mission
+Deliver a trustworthy, ad-free Islamic video experience curated strictly upon Quran and Sunnah per the understanding of the Sahabah. Albunyaan Tube surfaces only pre-approved YouTube IDs, avoids algorithmic rabbit holes, and provides respectful offline-first access for families worldwide.
+
+## Goals
+1. **Halal-first catalog**: 100% of surfaced content is vetted by admin/moderation workflows.
+2. **Frictionless consumption**: Mid-range Android device cold start under 2.5 seconds, with smooth playback and background audio.
+3. **Operational governance**: All catalog mutations audited; moderation turnaround <24h.
+4. **Inclusive localization**: Launch with English, Arabic (RTL), and Dutch with full UI parity.
+
+## Success Metrics
+- **Adherence**: <0.1% of surfaced items flagged for policy violation (monitored via audit + user reports).
+- **Performance**: 95th percentile home feed render <1.2s after data available.
+- **Engagement**: ≥60% of sessions start playback; ≥40% use audio-only or downloads weekly.
+- **Moderation SLA**: 90% of proposals triaged within 12 hours.
+- **Localization Quality**: Zero blocker bugs in L10n QA checklist across en/ar/nl.
+
+## Non-Goals
+- No user-generated comments, likes, or algorithmic recommendations.
+- No monetization features (ads, subscriptions) in initial scope.
+- No content ingestion beyond allow-listed YouTube IDs.
+
+## Stakeholders & Responsibilities
+- **Product Lead**: requirements, roadmap, acceptance (refs: [`docs/roadmap/roadmap.md`](../roadmap/roadmap.md)).
+- **Principal Engineer**: architecture, security, performance (refs: [`docs/architecture/solution-architecture.md`](../architecture/solution-architecture.md)).
+- **Design Lead**: UX/UI fidelity (refs: [`docs/ux/ui-spec.md`](../ux/ui-spec.md)).
+- **Localization Lead**: en/ar/nl strategy (refs: [`../i18n/strategy.md`](../i18n/strategy.md)).
+- **Moderation Lead**: content policy, audit (refs: [`../security/threat-model.md`](../security/threat-model.md)).
+
+## Assumptions
+- Access to NewPipeExtractor and YouTube assets complies with fair-use and platform ToS.
+- Content rights for offline downloads granted by Albunyaan Tube policy board.
+- Admin and moderator roles staffed 24/7 for SLA compliance.
+- Android is primary client at launch; web clients (consumer-facing) are out of scope.
+
+## Risks (see [`docs/risk-register.md`](../risk-register.md))
+- YouTube policy changes affecting extraction.
+- Localization complexities in Arabic script shaping.
+- Potential legal exposure for offline downloads.
+
+## Traceability
+This vision maps to detailed acceptance criteria in [`docs/acceptance/criteria.md`](../acceptance/criteria.md) and the backlog in [`docs/backlog/product-backlog.csv`](../backlog/product-backlog.csv).


### PR DESCRIPTION
## Summary
- add comprehensive discovery, roadmap, and solution architecture documentation for Albunyaan Tube
- define API surface with OpenAPI draft and supporting JSON Schemas covering registry, moderation, auth, and admin flows
- capture UX specifications, design tokens, i18n strategy, testing approach, acceptance criteria, backlog, and risk register

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dac31ff27c832398f54d6fb692732b