### PR TITLE
Complete YouTube DTO refactor phase 3

### DIFF
--- a/backend/src/main/java/com/albunyaan/tube/controller/YouTubeSearchController.java
+++ b/backend/src/main/java/com/albunyaan/tube/controller/YouTubeSearchController.java
@@ -1,6 +1,12 @@
 package com.albunyaan.tube.controller;
 
-import com.albunyaan.tube.dto.*;
+import com.albunyaan.tube.dto.ChannelDetailsDto;
+import com.albunyaan.tube.dto.EnrichedSearchResult;
+import com.albunyaan.tube.dto.PlaylistDetailsDto;
+import com.albunyaan.tube.dto.PlaylistItemDto;
+import com.albunyaan.tube.dto.SearchPageResponse;
+import com.albunyaan.tube.dto.StreamDetailsDto;
+import com.albunyaan.tube.dto.StreamItemDto;
 import com.albunyaan.tube.service.YouTubeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * FIREBASE-MIGRATE-04: YouTube Search Controller
@@ -252,11 +257,10 @@ public class YouTubeSearchController {
     @GetMapping("/channels/{channelId}")
     public ResponseEntity<ChannelDetailsDto> getChannelDetails(@PathVariable String channelId) {
         try {
-            var channel = youtubeService.getChannelDetails(channelId);
-            if (channel == null) {
+            ChannelDetailsDto dto = youtubeService.getChannelDetailsDto(channelId);
+            if (dto == null) {
                 return ResponseEntity.notFound().build();
             }
-            ChannelDetailsDto dto = youtubeService.mapToChannelDetailsDto(channel);
             return ResponseEntity.ok(dto);
         } catch (IOException e) {
             return ResponseEntity.status(500).build();
@@ -276,10 +280,7 @@ public class YouTubeSearchController {
             @RequestParam(required = false) String q
     ) {
         try {
-            var videos = youtubeService.getChannelVideos(channelId, pageToken, q);
-            List<StreamItemDto> dtos = videos.stream()
-                    .map(youtubeService::mapToStreamItemDto)
-                    .collect(Collectors.toList());
+            List<StreamItemDto> dtos = youtubeService.getChannelVideosDto(channelId, pageToken, q);
             return ResponseEntity.ok(dtos);
         } catch (IOException e) {
             return ResponseEntity.status(500).build();
@@ -295,10 +296,7 @@ public class YouTubeSearchController {
             @RequestParam(required = false) String pageToken
     ) {
         try {
-            var playlists = youtubeService.getChannelPlaylists(channelId, pageToken);
-            List<PlaylistItemDto> dtos = playlists.stream()
-                    .map(youtubeService::mapToPlaylistItemDto)
-                    .collect(Collectors.toList());
+            List<PlaylistItemDto> dtos = youtubeService.getChannelPlaylistsDto(channelId, pageToken);
             return ResponseEntity.ok(dtos);
         } catch (IOException e) {
             return ResponseEntity.status(500).build();
@@ -311,11 +309,10 @@ public class YouTubeSearchController {
     @GetMapping("/playlists/{playlistId}")
     public ResponseEntity<PlaylistDetailsDto> getPlaylistDetails(@PathVariable String playlistId) {
         try {
-            var playlist = youtubeService.getPlaylistDetails(playlistId);
-            if (playlist == null) {
+            PlaylistDetailsDto dto = youtubeService.getPlaylistDetailsDto(playlistId);
+            if (dto == null) {
                 return ResponseEntity.notFound().build();
             }
-            PlaylistDetailsDto dto = youtubeService.mapToPlaylistDetailsDto(playlist);
             return ResponseEntity.ok(dto);
         } catch (IOException e) {
             return ResponseEntity.status(500).build();
@@ -335,10 +332,7 @@ public class YouTubeSearchController {
             @RequestParam(required = false) String q
     ) {
         try {
-            var items = youtubeService.getPlaylistVideos(playlistId, pageToken, q);
-            List<StreamItemDto> dtos = items.stream()
-                    .map(youtubeService::mapToStreamItemDto)
-                    .collect(Collectors.toList());
+            List<StreamItemDto> dtos = youtubeService.getPlaylistVideosDto(playlistId, pageToken, q);
             return ResponseEntity.ok(dtos);
         } catch (IOException e) {
             return ResponseEntity.status(500).build();
@@ -351,11 +345,10 @@ public class YouTubeSearchController {
     @GetMapping("/videos/{videoId}")
     public ResponseEntity<StreamDetailsDto> getVideoDetails(@PathVariable String videoId) {
         try {
-            var video = youtubeService.getVideoDetails(videoId);
-            if (video == null) {
+            StreamDetailsDto dto = youtubeService.getVideoDetailsDto(videoId);
+            if (dto == null) {
                 return ResponseEntity.notFound().build();
             }
-            StreamDetailsDto dto = youtubeService.mapToStreamDetailsDto(video);
             return ResponseEntity.ok(dto);
         } catch (IOException e) {
             return ResponseEntity.status(500).build();

--- a/backend/src/main/java/com/albunyaan/tube/service/README-DTO-REFACTOR.md
+++ b/backend/src/main/java/com/albunyaan/tube/service/README-DTO-REFACTOR.md
@@ -155,13 +155,15 @@ public List<StreamItemDto> getChannelVideosDto(String channelId, String pageToke
 // ... similar for all operations
 ```
 
-### Phase 3: Migrate Service Callers
+### Phase 3: Migrate Service Callers ✅ (Completed)
 
-Update services that consume NewPipe types:
+All production callers that previously referenced NewPipe types now exclusively consume DTOs:
 
-1. **VideoValidationService** - Update to use DTO methods
-2. **SimpleImportService** - Update to use DTO methods
-3. **Any other internal callers** - Audit and update
+1. **VideoValidationService** – uses `batchValidateVideosDto(...)` for validation runs (presence/absence semantics preserved).
+2. **SimpleImportService** – maps `ChannelDetailsDto`, `PlaylistDetailsDto`, and `StreamDetailsDto` onto Firestore models.
+3. **YouTubeSearchController** – serves DTOs directly from `YouTubeService` without manual mapping.
+
+Guardrail enforced: No new imports of `org.schabi.newpipe.*` are allowed outside `ChannelOrchestrator`, `YouTubeGateway`, and legacy-focused tests. Current production code complies with this restriction.
 
 ### Phase 4: Deprecate NewPipe-Returning Methods
 
@@ -179,10 +181,7 @@ public ChannelInfo getChannelDetails(String channelId) throws IOException { ... 
 
 1. Remove deprecated methods after confirming no callers
 2. Consider moving mapping logic to a dedicated `DtoMapper` class
-3. Add guardrail: NewPipe types should only appear in:
-   - `YouTubeGateway`
-   - `ChannelOrchestrator` (internal only)
-   - Tests
+3. Formalize/static-check the guardrail so only `YouTubeGateway`, `ChannelOrchestrator`, and service-layer tests reference NewPipe types
 
 ## Controller Status
 

--- a/backend/src/main/java/com/albunyaan/tube/service/README-DTO-REFACTOR.md
+++ b/backend/src/main/java/com/albunyaan/tube/service/README-DTO-REFACTOR.md
@@ -165,8 +165,8 @@ All production callers that previously referenced NewPipe types now exclusively 
 
 Guardrail status: Imports of `org.schabi.newpipe.*` must remain confined to `YouTubeGateway`, `ChannelOrchestrator`, or clearly documented legacy seams. The following production files are **known exceptions** that still rely on NewPipe internals and therefore need follow-up refactors:
 
-1. `backend/src/main/java/com/albunyaan/tube/service/YouTubeService.java` (lines 10-14) – exposes legacy validation/search helpers that still surface `ChannelInfo`, `PlaylistInfo`, and `StreamInfo` for downstream callers.
-2. `backend/src/main/java/com/albunyaan/tube/dto/EnrichedSearchResult.java` (lines 4-7) – DTO factory helpers use `ChannelInfoItem`, `PlaylistInfoItem`, and `StreamInfoItem` directly when constructing enriched search payloads.
+1. `backend/src/main/java/com/albunyaan/tube/service/YouTubeService.java` (lines 10-14) – exposes legacy validation/search helpers that still surface `org.schabi.newpipe.extractor.channel.ChannelInfo`, `org.schabi.newpipe.extractor.playlist.PlaylistInfo`, `org.schabi.newpipe.extractor.playlist.PlaylistInfoItem`, `org.schabi.newpipe.extractor.stream.StreamInfo`, and `org.schabi.newpipe.extractor.stream.StreamInfoItem` for downstream callers.
+2. `backend/src/main/java/com/albunyaan/tube/dto/EnrichedSearchResult.java` (lines 4-7) – DTO factory helpers use `org.schabi.newpipe.extractor.Image`, `org.schabi.newpipe.extractor.channel.ChannelInfoItem`, `org.schabi.newpipe.extractor.playlist.PlaylistInfoItem`, and `org.schabi.newpipe.extractor.stream.StreamInfoItem` directly when constructing enriched search payloads.
 3. `backend/src/main/java/com/albunyaan/tube/config/NewPipeConfiguration.java` (lines 3-12) – bootstraps the shared NewPipe extractor beans, so it necessarily imports extractor primitives.
 4. `backend/src/main/java/com/albunyaan/tube/service/SearchOrchestrator.java` (lines 5-12) – still manipulates `InfoItem`/`SearchExtractor` objects while translating them into DTOs.
 

--- a/backend/src/main/java/com/albunyaan/tube/service/VideoValidationService.java
+++ b/backend/src/main/java/com/albunyaan/tube/service/VideoValidationService.java
@@ -1,5 +1,6 @@
 package com.albunyaan.tube.service;
 
+import com.albunyaan.tube.dto.StreamDetailsDto;
 import com.albunyaan.tube.model.SourceType;
 import com.albunyaan.tube.model.ValidationRun;
 import com.albunyaan.tube.model.ValidationStatus;
@@ -93,8 +94,8 @@ public class VideoValidationService {
                     .collect(Collectors.toList());
 
             // Batch validate against YouTube API
-            Map<String, org.schabi.newpipe.extractor.stream.StreamInfo> validVideos =
-                    youtubeService.batchValidateVideos(youtubeIds);
+            Map<String, StreamDetailsDto> validVideos =
+                    youtubeService.batchValidateVideosDto(youtubeIds);
 
             // Process results
             int checkedCount = 0;
@@ -259,8 +260,8 @@ public class VideoValidationService {
                     .collect(Collectors.toList());
 
             // Batch validate
-            Map<String, org.schabi.newpipe.extractor.stream.StreamInfo> validVideos =
-                    youtubeService.batchValidateVideos(youtubeIds);
+            Map<String, StreamDetailsDto> validVideos =
+                    youtubeService.batchValidateVideosDto(youtubeIds);
 
             // Process results
             int checkedCount = 0;

--- a/backend/src/test/java/com/albunyaan/tube/controller/YouTubeSearchControllerTest.java
+++ b/backend/src/test/java/com/albunyaan/tube/controller/YouTubeSearchControllerTest.java
@@ -1,0 +1,93 @@
+package com.albunyaan.tube.controller;
+
+import com.albunyaan.tube.dto.ChannelDetailsDto;
+import com.albunyaan.tube.dto.StreamDetailsDto;
+import com.albunyaan.tube.dto.StreamItemDto;
+import com.albunyaan.tube.repository.ChannelRepository;
+import com.albunyaan.tube.repository.PlaylistRepository;
+import com.albunyaan.tube.repository.VideoRepository;
+import com.albunyaan.tube.service.YouTubeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class YouTubeSearchControllerTest {
+
+    @Mock
+    private YouTubeService youtubeService;
+
+    @Mock
+    private ChannelRepository channelRepository;
+
+    @Mock
+    private PlaylistRepository playlistRepository;
+
+    @Mock
+    private VideoRepository videoRepository;
+
+    private YouTubeSearchController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new YouTubeSearchController(
+                youtubeService,
+                channelRepository,
+                playlistRepository,
+                videoRepository
+        );
+    }
+
+    @Test
+    void getChannelDetails_returnsDtoDirectly() throws Exception {
+        ChannelDetailsDto dto = new ChannelDetailsDto();
+        dto.setId("UC123");
+        when(youtubeService.getChannelDetailsDto("UC123")).thenReturn(dto);
+
+        ResponseEntity<ChannelDetailsDto> response = controller.getChannelDetails("UC123");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertSame(dto, response.getBody());
+        verify(youtubeService).getChannelDetailsDto("UC123");
+        verify(youtubeService, never()).mapToChannelDetailsDto(any());
+    }
+
+    @Test
+    void getChannelVideos_usesDtoOverloadWithSearch() throws Exception {
+        StreamItemDto item = new StreamItemDto();
+        when(youtubeService.getChannelVideosDto("UC123", "token", "filter")).thenReturn(List.of(item));
+
+        ResponseEntity<List<StreamItemDto>> response = controller.getChannelVideos("UC123", "token", "filter");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(List.of(item), response.getBody());
+        verify(youtubeService).getChannelVideosDto("UC123", "token", "filter");
+        verify(youtubeService, never()).mapToStreamItemDto(any());
+    }
+
+    @Test
+    void getVideoDetails_returnsNotFoundWhenDtoMissing() throws Exception {
+        when(youtubeService.getVideoDetailsDto("vid-1")).thenReturn(null);
+
+        ResponseEntity<StreamDetailsDto> response = controller.getVideoDetails("vid-1");
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertTrue(response.getBody() == null);
+        verify(youtubeService).getVideoDetailsDto("vid-1");
+        verify(youtubeService, never()).mapToStreamDetailsDto(any());
+    }
+}

--- a/backend/src/test/java/com/albunyaan/tube/service/SimpleImportServiceTest.java
+++ b/backend/src/test/java/com/albunyaan/tube/service/SimpleImportServiceTest.java
@@ -1,0 +1,158 @@
+package com.albunyaan.tube.service;
+
+import com.albunyaan.tube.dto.ChannelDetailsDto;
+import com.albunyaan.tube.dto.PlaylistDetailsDto;
+import com.albunyaan.tube.dto.SimpleImportResponse;
+import com.albunyaan.tube.dto.StreamDetailsDto;
+import com.albunyaan.tube.model.Channel;
+import com.albunyaan.tube.model.Playlist;
+import com.albunyaan.tube.model.Video;
+import com.albunyaan.tube.repository.ChannelRepository;
+import com.albunyaan.tube.repository.PlaylistRepository;
+import com.albunyaan.tube.repository.VideoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SimpleImportServiceTest {
+
+    @Mock
+    private YouTubeService youTubeService;
+
+    @Mock
+    private CategoryMappingService categoryMappingService;
+
+    @Mock
+    private ChannelRepository channelRepository;
+
+    @Mock
+    private PlaylistRepository playlistRepository;
+
+    @Mock
+    private VideoRepository videoRepository;
+
+    private SimpleImportService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SimpleImportService(
+                youTubeService,
+                categoryMappingService,
+                channelRepository,
+                playlistRepository,
+                videoRepository
+        );
+    }
+
+    @Test
+    void importSimpleFormat_channelUsesDtoMetadata() throws Exception {
+        Map<String, String> channels = Map.of("UC123", "Fallback Title|CatA");
+        List<Map<String, String>> payload = List.of(channels, Collections.emptyMap(), Collections.emptyMap());
+
+        ChannelDetailsDto dto = new ChannelDetailsDto();
+        dto.setId("UC123");
+        dto.setName("DTO Channel");
+        dto.setDescription("DTO Description");
+        dto.setThumbnailUrl("https://img.example/channel.jpg");
+        dto.setSubscriberCount(5_000L);
+
+        when(channelRepository.findByYoutubeId("UC123")).thenReturn(Optional.empty());
+        when(youTubeService.validateAndFetchChannelDto("UC123")).thenReturn(dto);
+        when(categoryMappingService.mapCategoryNamesToIds("CatA")).thenReturn(List.of("cat-1"));
+        when(channelRepository.save(any(Channel.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SimpleImportResponse response = service.importSimpleFormat(payload, "APPROVED", "user-1", false);
+
+        ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
+        verify(channelRepository).save(channelCaptor.capture());
+        Channel saved = channelCaptor.getValue();
+
+        assertEquals("DTO Channel", saved.getName());
+        assertEquals("DTO Description", saved.getDescription());
+        assertEquals("https://img.example/channel.jpg", saved.getThumbnailUrl());
+        assertEquals(5_000L, saved.getSubscribers());
+        assertEquals(List.of("cat-1"), saved.getCategoryIds());
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
+    void importSimpleFormat_playlistMapsDtoFields() throws Exception {
+        Map<String, String> playlists = Map.of("PL123", "Playlist Title|CatB");
+        List<Map<String, String>> payload = List.of(Collections.emptyMap(), playlists, Collections.emptyMap());
+
+        PlaylistDetailsDto dto = new PlaylistDetailsDto();
+        dto.setId("PL123");
+        dto.setName("DTO Playlist");
+        dto.setDescription("Playlist description");
+        dto.setThumbnailUrl("https://img.example/playlist.jpg");
+        dto.setStreamCount(42L);
+
+        when(playlistRepository.findByYoutubeId("PL123")).thenReturn(Optional.empty());
+        when(youTubeService.validateAndFetchPlaylistDto("PL123")).thenReturn(dto);
+        when(categoryMappingService.mapCategoryNamesToIds("CatB")).thenReturn(List.of("cat-2"));
+        when(playlistRepository.save(any(Playlist.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.importSimpleFormat(payload, "PENDING", "user-2", false);
+
+        ArgumentCaptor<Playlist> playlistCaptor = ArgumentCaptor.forClass(Playlist.class);
+        verify(playlistRepository).save(playlistCaptor.capture());
+        Playlist saved = playlistCaptor.getValue();
+
+        assertEquals("DTO Playlist", saved.getTitle());
+        assertEquals("Playlist description", saved.getDescription());
+        assertEquals("https://img.example/playlist.jpg", saved.getThumbnailUrl());
+        assertEquals(42, saved.getItemCount());
+        assertEquals(List.of("cat-2"), saved.getCategoryIds());
+    }
+
+    @Test
+    void importSimpleFormat_videoMapsDtoFields() throws Exception {
+        Map<String, String> videos = Map.of("VID123", "Video Title|CatC");
+        List<Map<String, String>> payload = List.of(Collections.emptyMap(), Collections.emptyMap(), videos);
+
+        StreamDetailsDto dto = new StreamDetailsDto();
+        dto.setId("VID123");
+        dto.setName("DTO Video");
+        dto.setDescription("Video description");
+        dto.setUploaderName("Uploader Name");
+        dto.setUploaderUrl("https://www.youtube.com/channel/UCCHAN123");
+        dto.setThumbnailUrl("https://img.example/video.jpg");
+        dto.setDuration(180L);
+        dto.setViewCount(1_000L);
+
+        when(videoRepository.findByYoutubeId("VID123")).thenReturn(Optional.empty());
+        when(youTubeService.validateAndFetchVideoDto("VID123")).thenReturn(dto);
+        when(categoryMappingService.mapCategoryNamesToIds("CatC")).thenReturn(List.of("cat-3"));
+        when(videoRepository.save(any(Video.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.importSimpleFormat(payload, "APPROVED", "user-3", false);
+
+        ArgumentCaptor<Video> videoCaptor = ArgumentCaptor.forClass(Video.class);
+        verify(videoRepository).save(videoCaptor.capture());
+        Video saved = videoCaptor.getValue();
+
+        assertEquals("DTO Video", saved.getTitle());
+        assertEquals("Video description", saved.getDescription());
+        assertEquals("UCCHAN123", saved.getChannelId());
+        assertEquals("Uploader Name", saved.getChannelTitle());
+        assertEquals("https://img.example/video.jpg", saved.getThumbnailUrl());
+        assertEquals(180, saved.getDurationSeconds());
+        assertEquals(1_000L, saved.getViewCount());
+        assertEquals(List.of("cat-3"), saved.getCategoryIds());
+    }
+}

--- a/backend/src/test/java/com/albunyaan/tube/service/VideoValidationServiceTest.java
+++ b/backend/src/test/java/com/albunyaan/tube/service/VideoValidationServiceTest.java
@@ -1,0 +1,100 @@
+package com.albunyaan.tube.service;
+
+import com.albunyaan.tube.dto.StreamDetailsDto;
+import com.albunyaan.tube.model.ValidationRun;
+import com.albunyaan.tube.model.ValidationStatus;
+import com.albunyaan.tube.model.Video;
+import com.albunyaan.tube.repository.ValidationRunRepository;
+import com.albunyaan.tube.repository.VideoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VideoValidationServiceTest {
+
+    @Mock
+    private VideoRepository videoRepository;
+
+    @Mock
+    private YouTubeService youtubeService;
+
+    @Mock
+    private AuditLogService auditLogService;
+
+    @Mock
+    private ValidationRunRepository validationRunRepository;
+
+    private VideoValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VideoValidationService(videoRepository, youtubeService, auditLogService, validationRunRepository);
+    }
+
+    @Test
+    void validateStandaloneVideos_marksUnavailableBasedOnDtoPresence() throws Exception {
+        Video validVideo = new Video("keep-me");
+        validVideo.setId("v-1");
+        Video missingVideo = new Video("remove-me");
+        missingVideo.setId("v-2");
+
+        when(videoRepository.findByStatus("APPROVED")).thenReturn(List.of(validVideo, missingVideo));
+        when(videoRepository.save(any(Video.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(validationRunRepository.save(any(ValidationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StreamDetailsDto dto = new StreamDetailsDto();
+        dto.setId("keep-me");
+        when(youtubeService.batchValidateVideosDto(anyList())).thenReturn(Map.of("keep-me", dto));
+
+        ValidationRun run = service.validateStandaloneVideos(
+                ValidationRun.TRIGGER_SCHEDULED,
+                null,
+                null,
+                null
+        );
+
+        assertEquals(2, run.getVideosChecked());
+        assertEquals(1, run.getVideosMarkedUnavailable());
+        assertSame(ValidationStatus.VALID, validVideo.getValidationStatus());
+        assertSame(ValidationStatus.UNAVAILABLE, missingVideo.getValidationStatus());
+
+        verify(youtubeService).batchValidateVideosDto(List.of("keep-me", "remove-me"));
+        verify(auditLogService).logSystem(eq("video_marked_unavailable"), eq("video"), eq("v-2"), any());
+    }
+
+    @Test
+    void validateSpecificVideos_countsUnavailableViaDtoMap() throws ExecutionException, InterruptedException, TimeoutException {
+        Video valid = new Video("exists");
+        Video missing = new Video("missing");
+
+        when(validationRunRepository.save(any(ValidationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StreamDetailsDto dto = new StreamDetailsDto();
+        dto.setId("exists");
+        when(youtubeService.batchValidateVideosDto(anyList())).thenReturn(Map.of("exists", dto));
+
+        ValidationRun result = service.validateSpecificVideos(List.of(valid, missing), ValidationRun.TRIGGER_IMPORT);
+
+        assertEquals(2, result.getVideosChecked());
+        assertEquals(1, result.getVideosMarkedUnavailable());
+        verify(youtubeService).batchValidateVideosDto(List.of("exists", "missing"));
+        verify(videoRepository, never()).save(any(Video.class));
+    }
+}


### PR DESCRIPTION
## Summary
- switch VideoValidationService, SimpleImportService, and YouTubeSearchController to the DTO-first YouTubeService APIs and remove direct NewPipe usage
- update README-DTO-REFACTOR.md to mark phase 3 complete and document the org.schabi.newpipe guardrail
- add targeted unit tests to cover the DTO flows in the updated services and controller

## Testing
- `cd backend && ./gradlew test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb97c27a883239b79b1250b5b1e69)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal data handling standardized to consistently use DTOs across search, import, and validation flows, with improved null-safety and field mapping for thumbnails, descriptions, and numeric stats.

* **Tests**
  * Added unit tests covering search responses, import formats (channel/playlist/video), and batch validation scenarios to reduce regressions.

* **Documentation**
  * Migration guide updated to mark Phase 3 complete, expand DTO migration details, guardrails, exceptions, and next steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->