### PR TITLE
[FEAT]: Edge-to-edge shell — fill navbar dead band

### DIFF
--- a/android/app/src/main/java/com/albunyaan/tube/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/albunyaan/tube/ui/MainActivity.kt
@@ -1,11 +1,14 @@
 package com.albunyaan.tube.ui
 
 import android.content.Intent
+import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.bundleOf
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -60,6 +63,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        configureSystemBars()
         navController // trigger lazy init if toolbar needed later
 
         // Handle intent only on fresh launch (not recreation)
@@ -538,6 +542,34 @@ class MainActivity : AppCompatActivity() {
             else -> AppCompatDelegate.MODE_NIGHT_NO
         }
         AppCompatDelegate.setDefaultNightMode(mode)
+    }
+
+    /**
+     * Edge-to-edge system bars ("transparent draw-behind"). The shell root
+     * ([MainShellFragment]) paints background_gray, so the strips behind BOTH
+     * (Android-15 transparent) system bars — the bottom nav strip (the dead-band
+     * fix) and the top status strip — read as the nav bar's colour instead of the
+     * window background. The status strip recolour is intentional and benign: at
+     * #F5F5F5 it sits within ~3/255 of the home content (#F5F6F8), closer than the
+     * prior off-white window background. Here we just stop the framework drawing a
+     * contrast scrim over the bottom strip and match the nav-bar icon colour to the
+     * current theme so the gesture pill / buttons stay legible.
+     *
+     * Scoped to Android 15+ (VANILLA_ICE_CREAM), where edge-to-edge and a
+     * transparent navigation bar are mandatory — that is the only place the
+     * white dead band appeared. On older APIs the nav bar stays opaque and its
+     * default colour/icon handling is left untouched. Status-bar transparency +
+     * light-status-bar are set in the theme (themes.xml). Re-runs on every
+     * recreate (theme toggle), so light/dark icon colour stays correct.
+     */
+    private fun configureSystemBars() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            window.isNavigationBarContrastEnforced = false
+            val isLight = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) !=
+                Configuration.UI_MODE_NIGHT_YES
+            WindowCompat.getInsetsController(window, window.decorView)
+                .isAppearanceLightNavigationBars = isLight
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/albunyaan/tube/ui/MainShellFragment.kt
+++ b/android/app/src/main/java/com/albunyaan/tube/ui/MainShellFragment.kt
@@ -59,10 +59,12 @@ class MainShellFragment : Fragment(R.layout.fragment_main_shell) {
             }
         }
 
-        // Prevent Material3's internal WindowInsets listener from adding bottom padding.
-        // The parent CoordinatorLayout's fitsSystemWindows="true" already positions the nav
-        // view above the system navigation bar. Without this, on Android 15+ (mandatory
-        // edge-to-edge), Material3 adds ADDITIONAL bottom padding, compressing the icons/labels.
+        // Prevent Material3's internal WindowInsets listener from adding bottom
+        // padding. The parent CoordinatorLayout's fitsSystemWindows="true" already
+        // positions the nav view above the system navigation bar; the white strip
+        // it leaves behind the (Android-15 transparent) system nav is filled by the
+        // shell root's background_gray, not by extending the bar. Without this
+        // swallow, Material3 adds ADDITIONAL bottom padding, compressing icons/labels.
         navigationView?.let { nav ->
             ViewCompat.setOnApplyWindowInsetsListener(nav) { _, insets -> insets }
         }

--- a/android/app/src/main/java/com/albunyaan/tube/ui/player/PlayerFragment.kt
+++ b/android/app/src/main/java/com/albunyaan/tube/ui/player/PlayerFragment.kt
@@ -738,7 +738,12 @@ class PlayerFragment : Fragment(R.layout.fragment_player) {
     }
 
     override fun onDestroyView() {
-        savedShellBackground = null
+        // NOTE: do NOT null savedShellBackground here. restoreShellRootView() below
+        // is what restores it, and on the back-while-fullscreen path the saved
+        // background (the shell's @color/background_gray) is still needed — nulling it
+        // first made the restore set the shell root background to null, which revives
+        // the white dead-band behind the transparent system nav. restoreShellRootView()
+        // clears the field itself once it has restored.
         pendingFullscreenExit = false
         pendingExitSafetyRunnable?.let { binding?.root?.removeCallbacks(it) }
         pendingExitSafetyRunnable = null
@@ -3798,14 +3803,21 @@ class PlayerFragment : Fragment(R.layout.fragment_player) {
     private fun restoreShellRootView() {
         findShellRootView()?.let { shellRoot ->
             shellRoot.fitsSystemWindows = true
-            // Restore the saved background instead of setting null.
-            // Setting null works for dark mode (window dark bg shows through) but breaks
-            // light mode on Samsung One UI where the CoordinatorLayout needs its explicit
-            // background to render correctly.
-            shellRoot.background = savedShellBackground
-            savedShellBackground = null
+            // Only restore a background we actually captured on fullscreen-enter
+            // (which swaps the shell root to black). When nothing was saved — the
+            // common case where the user never entered fullscreen, or it was already
+            // restored — leave the shell's own XML @color/background_gray in place.
+            // Setting it to null here previously revived the white dead-band behind
+            // the transparent system nav on light mode / Samsung One UI.
+            savedShellBackground?.let { saved -> shellRoot.background = saved }
             shellRoot.requestApplyInsets()
         }
+        // Always clear the capture — even if the shell root could not be found during
+        // teardown (parent shell already detached) — so a stale drawable from a prior
+        // view instance can't be re-applied on a later fullscreen cycle (cubic P3).
+        // PlayerFragment isn't retained, so this is belt-and-suspenders, but it keeps
+        // the save/restore contract airtight.
+        savedShellBackground = null
     }
 
     private fun loadMediaToCast() {

--- a/android/app/src/main/res/layout-sw600dp/fragment_main_shell.xml
+++ b/android/app/src/main/res/layout-sw600dp/fragment_main_shell.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
+    android:background="@color/background_gray"
     android:layoutDirection="locale">
 
     <!-- NavigationRail for tablets (left side, menu items centered via menuGravity) -->

--- a/android/app/src/main/res/layout-sw720dp/fragment_main_shell.xml
+++ b/android/app/src/main/res/layout-sw720dp/fragment_main_shell.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
+    android:background="@color/background_gray"
     android:layoutDirection="locale">
 
     <!-- NavigationRail for large tablets/TV (optimized for 10-foot D-pad navigation) -->

--- a/android/app/src/main/res/layout/fragment_main_shell.xml
+++ b/android/app/src/main/res/layout/fragment_main_shell.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
+    android:background="@color/background_gray"
     android:layoutDirection="locale">
 
     <androidx.fragment.app.FragmentContainerView


### PR DESCRIPTION
## ANDROID-SHELL-01 — kill the white dead band under the bottom nav (Android 15 edge-to-edge)

On Android 15's forced edge-to-edge, the lifted bottom nav exposed the white window background in the strip behind the now-transparent system nav. This fills it **without moving the nav bar**, so the Shorts overlay (which hard-codes `bottom_nav_height`) and the nav bar stay byte-identical to beta.28.

### Changes (2 commits)
1. **Fill the band** — paint the shell root (`fragment_main_shell`, all 3 variants) with `@color/background_gray`. Because the root paints the full window rect, it backs both transparent system-bar strips (bottom nav + top status); the top recolour is benign (#F5F5F5, within ~3/255 of the home content, closer than the prior off-white window bg). `MainActivity.configureSystemBars` (API 35+) drops the framework contrast scrim + sets nav-bar icon appearance per theme.
2. **Keep the band on player teardown** — `PlayerFragment.onDestroyView` was nulling the shell `background_gray` on every video exit (reviving the band), matching the "breaks light mode on Samsung One UI" warning already in `restoreShellRootView`. Removed the premature field-null + null-guarded the restore + unconditional field-clear (cubic hardening).

> An earlier attempt extended the nav bar behind the system nav; it killed the band but shifted the Shorts title/gradient overlay off the bar. Reverted in favour of the root-background approach, which decouples the band fix from the bar.

### Review (mandatory 7-stage pipeline — all clean)
- code-reviewer + cso + codex (gpt-5.5): no P0/P1
- `/review` fresh-eyes pass **caught the player-teardown regression** (the cross-file interaction the in-diff reviewers missed) → fixed + re-reviewed
- cubic: 2 consecutive clean rounds (1 P3 fixed)
- 1317 unit tests green; debug + release compile clean

### Verified
SM-S938U (3-button nav, 450dpi): strip behind the system nav is continuous gray, no white. Nav bar, Shorts overlay, and labels unchanged from beta.28. All 3 player-teardown paths re-traced to end at `background_gray`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the white strip under the bottom nav on Android 15 edge-to-edge by filling the system-bar area from the shell root; keeps nav bar geometry and the Shorts overlay unchanged. Addresses ANDROID-SHELL-01.

- **New Features**
  - Set `@color/background_gray` on the shell root (`fragment_main_shell` in all size variants) and swallow Material3 bottom insets so layout stays the same while the transparent system bars are backed.
  - On Android 15+, `configureSystemBars()` disables the nav-bar contrast scrim and sets light/dark nav icon appearance to match the theme.

- **Bug Fixes**
  - Prevent the player teardown from clearing the shell background: don’t null `savedShellBackground` early; restore only if captured, then clear after restore to avoid reviving the white band.

<sup>Written for commit 24a13833d243462db02ec14cb1bdbf0b0edfdb4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/talibfitrah/albunyaantube/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

